### PR TITLE
Fixed Artifactory URL in Readme

### DIFF
--- a/charts/acp/README.md
+++ b/charts/acp/README.md
@@ -66,7 +66,7 @@ ACP defines Pod that uses a Secret to pull an image from a private Docker regist
 To manually configure Docker credentials, first createreate a Secret by providing credentials on the command line:
 
 ```console
-kubectl create secret docker-registry artifactory --docker-server=artifactory.cloudentity.com --docker-username=<your-name> --docker-password=<your-password>
+kubectl create secret docker-registry artifactory --docker-server=acp.artifactory.cloudentity.com --docker-username=<your-name> --docker-password=<your-password>
 ```
 
 ### RBAC Configuration


### PR DESCRIPTION
It seems that the repo url was incorrect.
Fixed it to point to acp.artifactory.cloudentity.com