### PR TITLE
use pem file as a source for financroo jwks

### DIFF
--- a/charts/openbanking/templates/import/configmap.yaml
+++ b/charts/openbanking/templates/import/configmap.yaml
@@ -14,14 +14,11 @@ data:
     financroo_tls_client_auth_subject_dn: CN=acp.local,OU= Authorization,O=Cloudentity,L=Seattle,ST=Washinghton,C=US
     bank_tls_client_auth_subject_dn: CN=acp.local,OU= Authorization,O=Cloudentity,L=Seattle,ST=Washinghton,C=US
     example_web_client_url: https://example.local:8443
-    financroo_jwks: |
-      keys:
-      - alg: RS256
-        e: AQAB
-        kid: "167467200346518873990055631921812347975180003245"
-        kty: RSA
-        "n": rcvUbtUo7hoNpzAMYDog6dxOBPSMhSW1L45Isf2R7mW0t8gpn5uN0xiO_stP3E4f1X2UjkdEy0zFuEOYtjL353JtYsHXmZzGb7PeWu6EEw9L9nFwa8N1lAguXcJR_fPol8kW3tzdxewl9y68GhAlxMKgrtHV8DVE94IohMAxwIT45pvruZCFkMLs0tyYnRQ5Epp5WGfaCGmJQgyI_66F0JoAazrzc_oCiHQ3XPXOx-tzqkkubjgjoTxxhRK3QqHiALwriK8mIMSllRU7pUUXNsYumYMm1DuzJxAJMr1ecgL4ksMGLy0kv8mWQTMjxPsUNCetpUSkj7de8qJaKcqVlQ
-        use: sig
+    financroo_pem_file: /tls/tls.key
+    {{- if .Values.import.readClientCertFromHeader }}
+    read_client_certificate_from_header: true
+    client_certificate_header: X-SSL-CERT
+    {{ end -}}
     {{- range $key, $value := .Values.import.variables }}
     {{ $key }}: {{ $value }}
     {{- end }}

--- a/charts/openbanking/templates/import/job.yaml
+++ b/charts/openbanking/templates/import/job.yaml
@@ -42,11 +42,17 @@ spec:
           volumeMounts:
             - name: variables
               mountPath: /app/vars
+            - mountPath: /tls
+              name: tls
+              readOnly: true
             {{- if .Values.import.extraTemplate }}
             - name: extra-templates
               mountPath: /app/extra-imports
             {{- end }}
       volumes:
+        - name: tls
+          secret:
+            secretName: {{ template "openbanking.fullname" . }}-tls
         - name: variables
           configMap:
             name: {{ template "openbanking.fullname" . -}}-variables


### PR DESCRIPTION
Use PEM file as a source of JWKs used by financroo.
This is based on the recent changes introduced in openbanking-quickstart allowing to do the pem -> jwks convertion.