### PR TITLE
Add import jobs options

### DIFF
--- a/charts/acp/Chart.yaml
+++ b/charts/acp/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: acp
 description: Cloudentity Authorization Control Plane
 type: application
-version: 0.13.2
+version: 0.13.3
 appVersion: "1.13.0"

--- a/charts/acp/templates/import.yaml
+++ b/charts/acp/templates/import.yaml
@@ -12,20 +12,41 @@ spec:
   backoffLimit: 4
   template:
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: data
+          configMap:
+            name: {{ include "acp.configName" . }}
+        - name: tls
+          secret:
+            secretName: {{ include "acp.fullname" . }}-tls
+            defaultMode: 384
+        - name: import
+          configMap:
+            name: {{ include "acp.fullname" . }}-import
+        - name: secret
+          secret:
+            secretName: {{ include "acp.secretConfig" . }}
+      serviceAccountName: {{ include "acp.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.importJob.args }}
           args:
-            - import
-            - --config
-            - /data/config.yaml,/secret/config.yaml
-            - --mode
-            - update
-            - --format
-            - yaml
-            - --input
-            - /import/seed.yaml
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /data
               name: data
@@ -39,19 +60,20 @@ spec:
             - mountPath: /secret
               name: secret
               readOnly: true
-      volumes:
-        - name: data
-          configMap:
-            name: {{ include "acp.configName" . }}
-        - name: tls
-          secret:
-            secretName: {{ include "acp.fullname" . }}-tls
-        - name: import
-          configMap:
-            name: {{ include "acp.fullname" . }}-import
-        - name: secret
-          secret:
-            secretName: {{ include "acp.secretConfig" . }}
+          resources:
+            {{- toYaml .Values.importJob.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: OnFailure
 ---
 apiVersion: v1

--- a/charts/acp/templates/import.yaml
+++ b/charts/acp/templates/import.yaml
@@ -39,10 +39,19 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- with .Values.importJob.args }}
           args:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+            - import
+            - --config
+            - {{ join "," .Values.importJob.config }}
+            - --mode
+            - {{ .Values.importJob.mode }}
+            - --format
+            - {{ .Values.importJob.format }}
+            - --input
+            - {{ .Values.importJob.input }}
+            {{- with .Values.importJob.extraArgs }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.env }}
           env:
             {{- toYaml . | nindent 12 }}

--- a/charts/acp/values.yaml
+++ b/charts/acp/values.yaml
@@ -148,16 +148,18 @@ certManager:
 
 importJob:
   enabled: false
-  args:
-    - import
-    - --config
-    - /data/config.yaml,/secret/config.yaml
-    - --mode
-    - update
-    - --format
-    - yaml
-    - --input
-    - /import/seed.yaml
+  # path to config files
+  config:
+    - /data/config,yaml
+    - /secret/config.yaml
+  # import mode (update, fail, ignore)
+  mode: update
+  # input file format: yaml or json
+  format: yaml
+  # path to the input file
+  input: /import/seed.yaml
+  # extra args for import command
+  extraArgs: []
   # the data should match import configuration endpoint request body
   # https://docs.authorization.cloudentity.com/api/system/#operation/importConfiguration
   data:

--- a/charts/acp/values.yaml
+++ b/charts/acp/values.yaml
@@ -148,12 +148,23 @@ certManager:
 
 importJob:
   enabled: false
+  args:
+    - import
+    - --config
+    - /data/config.yaml,/secret/config.yaml
+    - --mode
+    - update
+    - --format
+    - yaml
+    - --input
+    - /import/seed.yaml
   # the data should match import configuration endpoint request body
   # https://docs.authorization.cloudentity.com/api/system/#operation/importConfiguration
   data:
     tenants: []
     servers: []
     clients: []
+  resources: {}
 
 ## Additional ACP config file from secret
 ##


### PR DESCRIPTION
Add importJob customization options

* Fix missing securityContext (job cannot read tls config file to connect to crdb)
* Add options to set custom importjob args (for custom config names like /secret/secret.yaml instead /secret/config.yaml)
* Use same ENVS as ACP (to set crdb uri etc)
* Add resource definitions
* Use same selectors as ACP