### PR TITLE
[DEVOPS-1448] Added 'disableTls' flag to acp chart values

### DIFF
--- a/charts/acp/templates/NOTES.txt
+++ b/charts/acp/templates/NOTES.txt
@@ -13,7 +13,7 @@
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "acp.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "acp.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
+  echo http://$SERVICE_IP:{{ include "acp.portNumber" . }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "acp.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")

--- a/charts/acp/templates/_helpers.tpl
+++ b/charts/acp/templates/_helpers.tpl
@@ -82,3 +82,14 @@ Create the name of the config to use
 {{- default "default" .Values.config.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the port number to use
+*/}}
+{{- define "acp.portNumber" -}}
+{{- if .Values.tlsDisabled }}
+{{- default 8080 }}
+{{- else }}
+{{- default 8443 }}
+{{- end }}
+{{- end }}

--- a/charts/acp/templates/configmap.yaml
+++ b/charts/acp/templates/configmap.yaml
@@ -14,6 +14,10 @@ data:
         cert_path: "/tls/tls.crt"
         key_path: "/tls/tls.key"
       {{- end }}
+      {{- if .Values.tlsDisabled }}
+      dangerous_disable_tls: true
+      {{- end }}
+      port: {{ include "acp.portNumber" . }}
     sql:
       {{- with .Values.sql }}
         {{- toYaml . | nindent 6 }}

--- a/charts/acp/templates/deployment.yaml
+++ b/charts/acp/templates/deployment.yaml
@@ -58,13 +58,17 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: 8443
+              containerPort: {{ include "acp.portNumber" . }}
               protocol: TCP
           livenessProbe:
             httpGet:
               path: /alive
+              {{- if .Values.tlsDisabled }}
+              scheme: HTTP
+              {{- else }}
               scheme: HTTPS
-              port: 8443
+              {{- end }}
+              port: {{ include "acp.portNumber" . }}
             initialDelaySeconds: 3
             failureThreshold: 1
             periodSeconds: 10
@@ -72,16 +76,24 @@ spec:
           startupProbe:
             httpGet:
               path: /alive
+              {{- if .Values.tlsDisabled }}
+              scheme: HTTP
+              {{- else }}
               scheme: HTTPS
-              port: 8443
+              {{- end }}
+              port: {{ include "acp.portNumber" . }}
             failureThreshold: 10
             periodSeconds: 10
             timeoutSeconds: 10
           readinessProbe:
             httpGet:
               path: /alive
+              {{- if .Values.tlsDisabled }}
+              scheme: HTTP
+              {{- else }}
               scheme: HTTPS
-              port: 8443
+              {{- end }}
+              port: {{ include "acp.portNumber" . }}
             initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 10

--- a/charts/acp/templates/ingress.yaml
+++ b/charts/acp/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "acp.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
+{{- $svcPort := include "acp.portNumber" . -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
@@ -11,10 +11,26 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "acp.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
+    kubernetes.io/ingress.class: nginx
+    {{- if .Values.tlsDisabled }}
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    {{- else }}
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    {{- end }}
+    nginx.ingress.kubernetes.io/proxy-ssl-ciphers: "EECDH+AESGCM:EDH+AESGCM"
+    nginx.ingress.kubernetes.io/proxy-ssl-protocols: "TLSv1.2"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
+    nginx.ingress.kubernetes.io/ssl-ciphers: "EECDH+AESGCM:EDH+AESGCM"
+    nginx.ingress.kubernetes.io/server-snippet: |
+      ssl_verify_client optional_no_ca;
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header X-SSL-CERT $ssl_client_escaped_cert;
+    {{- with .Values.ingress.customAnnotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 spec:
   {{- if .Values.ingress.tls }}
   tls:

--- a/charts/acp/templates/service.yaml
+++ b/charts/acp/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
+    - port: {{ include "acp.portNumber" . }}
       targetPort: http
       protocol: TCP
       name: http

--- a/charts/acp/values.yaml
+++ b/charts/acp/values.yaml
@@ -63,30 +63,14 @@ service:
   ##
   type: ClusterIP
 
-  ## ACP service HTTP port
-  ##
-  port: 8443
-
 ingress:
   ## Enables the Ingress for ACP
   ##
   enabled: true
 
-  ## Ingress annotations
+  ## Ingress additional custom annotations
   ##
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-    nginx.ingress.kubernetes.io/proxy-ssl-ciphers: "EECDH+AESGCM:EDH+AESGCM"
-    nginx.ingress.kubernetes.io/proxy-ssl-protocols: "TLSv1.2"
-    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
-    nginx.ingress.kubernetes.io/ssl-ciphers: "EECDH+AESGCM:EDH+AESGCM"
-    nginx.ingress.kubernetes.io/server-snippet: |
-      ssl_verify_client optional_no_ca;
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      proxy_set_header X-SSL-CERT $ssl_client_escaped_cert;
+  customAnnotations:
 
   ## Ingress hostnames with paths
   ##
@@ -145,6 +129,10 @@ features:
 ##
 certManager:
   enabled: false
+
+## Disables TLS in ACP
+##
+tlsDisabled: false
 
 importJob:
   enabled: false


### PR DESCRIPTION
Jira issue: [DEVOPS-1448](https://cloudentity.atlassian.net/browse/DEVOPS-1448)

This feature adds `disableTls` option (with `false` default value) to the ACP helm chart.

If the option is set to `true`, ACP port number and protocol will change to HTTP values (no TLS).