### PR TITLE
AUT-3538/update redis

### DIFF
--- a/charts/acp/templates/configmap.yaml
+++ b/charts/acp/templates/configmap.yaml
@@ -41,7 +41,9 @@ data:
       {{- else }}
       enabled: true
       addrs:
-      - "{{ .Release.Name }}-redis-cluster:6379"
+      - "{{ .Release.Name }}-redis-cluster-0.{{ .Release.Name }}-redis-cluster-headless:6379"
+      - "{{ .Release.Name }}-redis-cluster-1.{{ .Release.Name }}-redis-cluster-headless:6379"
+      - "{{ .Release.Name }}-redis-cluster-2.{{ .Release.Name }}-redis-cluster-headless:6379"
       {{- end }}
     {{- with .Values.features }}
     features:

--- a/charts/acp/templates/configmap.yaml
+++ b/charts/acp/templates/configmap.yaml
@@ -27,7 +27,7 @@ data:
       {{- with .Values.sql }}
         {{- toYaml . | nindent 6 }}
       {{- else }}
-      url: "postgres://root@{{ .Release.Name }}-cockroachdb:26257/defaultdb?sslmode=disable"
+      url: "postgres://root@{{ .Release.Name }}-cockroachdb-public:26257/defaultdb?sslmode=disable"
       {{- end }}
     hazelcast:
       {{- with .Values.hazelcast }}

--- a/charts/acp/templates/configmap.yaml
+++ b/charts/acp/templates/configmap.yaml
@@ -41,7 +41,7 @@ data:
       {{- else }}
       enabled: true
       addrs:
-      - "{{ .Release.Name }}-redis-master:6379"
+      - "{{ .Release.Name }}-redis-cluster:6379"
       {{- end }}
     {{- with .Values.features }}
     features:

--- a/charts/kube-acp-stack/Chart.yaml
+++ b/charts/kube-acp-stack/Chart.yaml
@@ -16,6 +16,5 @@ dependencies:
   condition: redis-cluster.enabled
 - name: acp
   version: "0.15.0"
-    #repository: https://charts.cloudentity.io
-  repository: file://../acp
+  repository: https://charts.cloudentity.io
   condition: acp.enabled

--- a/charts/kube-acp-stack/Chart.yaml
+++ b/charts/kube-acp-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-acp-stack
 description: kube-acp-stack collects acp charts combined with documentation and scripts to provide easy to operate end-to-end Kubernetes cluster
 type: application
-version: 0.15.0
+version: 0.15.1
 sources:
   - https://github.com/cloudentity/acp-helm-charts
 dependencies:
@@ -10,11 +10,12 @@ dependencies:
   version: "5.0.7"
   repository: https://charts.cockroachdb.com
   condition: cockroachdb.enabled
-- name: redis
-  version: "14.8.3"
+- name: redis-cluster
+  version: "7.0.9"
   repository: https://charts.bitnami.com/bitnami
-  condition: redis.enabled
+  condition: redis-cluster.enabled
 - name: acp
   version: "0.15.0"
-  repository: https://charts.cloudentity.io
+    #repository: https://charts.cloudentity.io
+  repository: file://../acp
   condition: acp.enabled

--- a/charts/kube-acp-stack/Chart.yaml
+++ b/charts/kube-acp-stack/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: kube-acp-stack
 description: kube-acp-stack collects acp charts combined with documentation and scripts to provide easy to operate end-to-end Kubernetes cluster
 type: application
-version: 0.15.1
+version: 0.15.0
 sources:
   - https://github.com/cloudentity/acp-helm-charts
 dependencies:
 - name: cockroachdb
-  version: "5.0.7"
+  version: "6.2.8"
   repository: https://charts.cockroachdb.com
   condition: cockroachdb.enabled
 - name: redis-cluster

--- a/charts/kube-acp-stack/README.md
+++ b/charts/kube-acp-stack/README.md
@@ -64,7 +64,7 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 
 ### From 0.14.x to 0.15.x
 
-Dependency redis helm chart was replaced by redis-cluster helm chart. The old redis instances will be destroyed in favour of new redis-cluster. Data migration is not supported but can me done manually which is out of the scope of this chart.
+Dependency redis helm chart was replaced by redis-cluster helm chart. The old redis instances will be destroyed in favour of new redis-cluster. Data migration is not supported but could be done manually which is out of the scope of this chart.
 
 ### From 0.6.x to 0.7.x
 

--- a/charts/kube-acp-stack/README.md
+++ b/charts/kube-acp-stack/README.md
@@ -62,6 +62,10 @@ $ helm upgrade [RELEASE_NAME] acp/kube-acp-stack
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
+### From 0.14.x to 0.15.x
+
+Dependency redis helm chart was replaced by redis-cluster helm chart. The old redis instances will be destroyed in favour of new redis-cluster. Data migration is not supported but can me done manually which is out of the scope of this chart.
+
 ### From 0.6.x to 0.7.x
 
 Version 1.10.0 of ACP changes the key names in feature flags from camelCase to snake_case [values.yaml](https://github.com/cloudentity/acp-helm-charts/commit/e150d8c713bc1b7eae0f5d272b77071b0c0b29bf#diff-8bff71ce1c243a3af0288410a6f5900e2c5d5bde86fbcbf8124615970237759a).

--- a/charts/kube-acp-stack/README.md
+++ b/charts/kube-acp-stack/README.md
@@ -1,6 +1,6 @@
 # kube-acp-stack
 
-Installs the [acp](https://github.com/cloudentity/acp-helm-charts/tree/master/charts/acp), a collection of Kubernetes manifests, [CockroachDB](https://www.cockroachlabs.com/) open source, cloud-native distributed SQL database, and [Hazelcast](https://hazelcast.com/) in-memory data grid combined with documentation and scripts to provide easy to operate end-to-end Authorization Control Plane cluster.
+Installs the [acp](https://github.com/cloudentity/acp-helm-charts/tree/master/charts/acp), a collection of Kubernetes manifests, [CockroachDB](https://www.cockroachlabs.com/) open source, cloud-native distributed SQL database, and [Redis](https://redis.io/) in-memory data grid combined with documentation and scripts to provide easy to operate end-to-end Authorization Control Plane cluster.
 
 See the [acp](https://github.com/cloudentity/acp-helm-charts/tree/master/charts/acp) README for details about components, capabilities of OAuth/OIDC server with an advanced authorization, consent management, and developer enablement.
 
@@ -35,7 +35,7 @@ By default this chart installs additional, dependent charts:
 
 - [acp/acp](https://github.com/cloudentity/acp-helm-charts/tree/master/charts/acp)
 - [cockroachdb/cockroachdb](https://github.com/cockroachdb/helm-charts/tree/master/cockroachdb)
-- [hazelcast/hazelcast](https://github.com/hazelcast/charts/tree/master/stable/hazelcast)
+- [redis-cluster/redis-cluster](https://github.com/bitnami/charts/tree/master/bitnami/redis-cluster)
 
 To disable dependencies during installation, see [multiple releases](#multiple-releases) below.
 
@@ -90,4 +90,4 @@ For more in-depth documentation of configuration options meanings, please see
 
 - [ACP](https://github.com/cloudentity/acp-helm-charts)
 - [CockroachDB](https://github.com/cockroachdb/helm-charts)
-- [Hazelcast](https://github.com/hazelcast/charts)
+- [redis-cluster](https://github.com/bitnami/charts)

--- a/charts/kube-acp-stack/values.yaml
+++ b/charts/kube-acp-stack/values.yaml
@@ -1,8 +1,35 @@
-cockroachdb:
-  enabled: true
-redis:
-  enabled: true
-  auth:
-    enabled: false
 acp:
   enabled: true
+  secretConfig:
+    data:
+      redis:
+        password: p@ssw0rd!
+cockroachdb:
+  enabled: true
+redis-cluster:
+  enabled: true
+  cluster:
+    nodes: 3
+    replicas: 0
+  redis:
+    password: p@ssw0rd!
+    configmap: |
+      loadmodule /redismodules/redisearch.so
+    initContainers:
+      - name: redisearch
+        image: redislabs/redisearch:2.2.0
+        command:
+          [
+            "sh",
+            "-c",
+            "cp /usr/lib/redis/modules/redisearch.so /redismodules/redisearch.so",
+          ]
+        volumeMounts:
+          - mountPath: /redismodules
+            name: redismodules
+    extraVolumes:
+      - name: redismodules
+        emptyDir: {}
+    extraVolumeMounts:
+      - mountPath: /redismodules
+        name: redismodules

--- a/charts/kube-acp-stack/values.yaml
+++ b/charts/kube-acp-stack/values.yaml
@@ -1,9 +1,9 @@
 acp:
   enabled: true
-  secretConfig:
-    data:
-      redis:
-        password: p@ssw0rd!
+    #  secretConfig:
+    #    data:
+    #      redis:
+    #        password: p@ssw0rd!
 cockroachdb:
   enabled: true
 redis-cluster:
@@ -11,8 +11,9 @@ redis-cluster:
   cluster:
     nodes: 3
     replicas: 0
+  usePassword: false
+    #    password: p@ssw0rd!
   redis:
-    password: p@ssw0rd!
     configmap: |
       loadmodule /redismodules/redisearch.so
     initContainers:

--- a/charts/kube-acp-stack/values.yaml
+++ b/charts/kube-acp-stack/values.yaml
@@ -1,18 +1,19 @@
 acp:
   enabled: true
-    #  secretConfig:
-    #    data:
-    #      redis:
-    #        password: p@ssw0rd!
+  secretConfig:
+    data:
+      redis:
+        password: p@ssw0rd!
 cockroachdb:
   enabled: true
+  tls:
+    enabled: false
 redis-cluster:
   enabled: true
   cluster:
     nodes: 3
     replicas: 0
-  usePassword: false
-    #    password: p@ssw0rd!
+  password: p@ssw0rd!
   redis:
     configmap: |
       loadmodule /redismodules/redisearch.so

--- a/charts/kube-acp-stack/values.yaml
+++ b/charts/kube-acp-stack/values.yaml
@@ -4,6 +4,10 @@ acp:
     data:
       redis:
         password: p@ssw0rd!
+  config:
+    data:
+      redis:
+        redis_search: true
 cockroachdb:
   enabled: true
   tls:


### PR DESCRIPTION
BREAKING CHANGE. Redis was replaced by redis-cluster

- general:
  - updated README
- kube-acp-stack:
  - Dependencies:
    - Update cockroachdb helm chart from 5.0.7 to 6.2.8
    - Removed redis helm chart
    - Added redis-cluster helm chart version 7.0.9
    - Add redisearch module 2.2.0
    - Enable redis password authentication
  - Added redis password authentication
  - Enable redis_search

- ACP:
  - Update default values for redis connection uri
  - Update default values for cockroachdb connection uri
