### PR TITLE
update ssl_verify_depth to support longer cert chains

### DIFF
--- a/charts/acp/templates/ingress.yaml
+++ b/charts/acp/templates/ingress.yaml
@@ -26,6 +26,7 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-ciphers: "EECDH+AESGCM:EDH+AESGCM"
     nginx.ingress.kubernetes.io/server-snippet: |
       ssl_verify_client optional_no_ca;
+      ssl_verify_depth 2;
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header X-SSL-CERT $ssl_client_escaped_cert;
     {{- with .Values.ingress.customAnnotations }}


### PR DESCRIPTION
## Description

This PR increases the ssl_verify_depth for client certs to 2. This is required to support OpenBanking Brazil.
The certs used by clients now include root_ca and the default value of `1` wasn't able to read the whole certificate and returned a 400.