### PR TITLE
bump acp helm version to 0.15.2

### DIFF
--- a/charts/acp/Chart.yaml
+++ b/charts/acp/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: acp
 description: Cloudentity Authorization Control Plane
 type: application
-version: 0.15.1
+version: 0.15.2
 appVersion: "1.15.0"

--- a/charts/kube-acp-stack/Chart.yaml
+++ b/charts/kube-acp-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-acp-stack
 description: kube-acp-stack collects acp charts combined with documentation and scripts to provide easy to operate end-to-end Kubernetes cluster
 type: application
-version: 0.15.1
+version: 0.15.2
 sources:
   - https://github.com/cloudentity/acp-helm-charts
 dependencies:
@@ -15,6 +15,6 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   condition: redis-cluster.enabled
 - name: acp
-  version: "0.15.0"
+  version: "0.15.2"
   repository: https://charts.cloudentity.io
   condition: acp.enabled


### PR DESCRIPTION
## Description

We've noticed a problem when trying to start `acp-on-k8s`.
Updated imagePullSecrets were not respected.

It turned out that `kube-acp-stack` helm charts were referencing  0.15.0 instead of 0.15.1
This PR bumps both `acp` and `kube-acp-stack` so charts will get updated.

## Type of changes

[x] Bugfix (non-breaking change which fixes an issue)
[] New feature (non-breaking change which adds functionality)
[] Tests (extending the test suite)
[] Refactor (internal improvement that doesn't change product functionality)
[] Other (if none of the other choices apply)