### PR TITLE
Revert redis-cluster

### DIFF
--- a/charts/acp/Chart.yaml
+++ b/charts/acp/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: acp
 description: Cloudentity Authorization Control Plane
 type: application
-version: 0.15.2
+version: 0.15.3
 appVersion: "1.15.0"

--- a/charts/acp/templates/configmap.yaml
+++ b/charts/acp/templates/configmap.yaml
@@ -41,9 +41,7 @@ data:
       {{- else }}
       enabled: true
       addrs:
-      - "{{ .Release.Name }}-redis-cluster-0.{{ .Release.Name }}-redis-cluster-headless:6379"
-      - "{{ .Release.Name }}-redis-cluster-1.{{ .Release.Name }}-redis-cluster-headless:6379"
-      - "{{ .Release.Name }}-redis-cluster-2.{{ .Release.Name }}-redis-cluster-headless:6379"
+      - "{{ .Release.Name }}-redis-master:6379"
       {{- end }}
     {{- with .Values.features }}
     features:

--- a/charts/kube-acp-stack/Chart.yaml
+++ b/charts/kube-acp-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-acp-stack
 description: kube-acp-stack collects acp charts combined with documentation and scripts to provide easy to operate end-to-end Kubernetes cluster
 type: application
-version: 0.15.2
+version: 0.15.3
 sources:
   - https://github.com/cloudentity/acp-helm-charts
 dependencies:
@@ -10,11 +10,11 @@ dependencies:
   version: "6.2.8"
   repository: https://charts.cockroachdb.com
   condition: cockroachdb.enabled
-- name: redis-cluster
-  version: "7.0.9"
+- name: redis
+  version: "15.6.1"
   repository: https://charts.bitnami.com/bitnami
-  condition: redis-cluster.enabled
+  condition: redis.enabled
 - name: acp
-  version: "0.15.2"
+  version: "0.15.3"
   repository: https://charts.cloudentity.io
   condition: acp.enabled

--- a/charts/kube-acp-stack/README.md
+++ b/charts/kube-acp-stack/README.md
@@ -61,13 +61,25 @@ $ helm upgrade [RELEASE_NAME] acp/kube-acp-stack
 
 _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
-### From 0.15.0 to 0.15.1
+### From 0.14.x to 0.15.3
 
 Version 0.15.1 of ACP kube stack helm chart uses `docker.cloudentity.io` as the secret name referencing Cloudentity registry.
 If you're using the `artifactory` and haven't overridden `imagePullSecrets` before, you have to create a new secret with the name `docker.cloudentity.io`
 See [Docker Pull Credentials](#docker-pull-credentials).
 
-### From 0.14.x to 0.15.x
+### From 0.15.x to 0.15.3
+
+Due to bug in ACP, redis-cluster implementation was reverted back to redis helm chart. Redis multi-master instances will be destroyed and recreated as master-replica. Data migration is not supported but could be done manually which is out of the scope of this chart.
+
+### From 0.15.0 to 0.15.1 
+
+Version 0.15.1 of ACP kube stack helm chart uses `docker.cloudentity.io` as the secret name referencing Cloudentity registry.
+If you're using the `artifactory` and haven't overridden `imagePullSecrets` before, you have to create a new secret with the name `docker.cloudentity.io`
+See [Docker Pull Credentials](#docker-pull-credentials).
+
+### From 0.14.x to 0.15.0, 0.15.1, 0.15.2
+
+!Releases 0.15.0, 0.15.1 and 0.15.2 shloud not be used due connectivity issues with redis. ACP might randomly fail to connect to redis. This will be fixed in upcomming ACP release!
 
 Dependency redis helm chart was replaced by redis-cluster helm chart. The old redis instances will be destroyed in favour of new redis-cluster. Data migration is not supported but could be done manually which is out of the scope of this chart.
 

--- a/charts/kube-acp-stack/values.yaml
+++ b/charts/kube-acp-stack/values.yaml
@@ -12,23 +12,42 @@ cockroachdb:
   enabled: true
   tls:
     enabled: false
-redis-cluster:
+redis:
   enabled: true
-  cluster:
-    nodes: 3
-    replicas: 0
-  password: p@ssw0rd!
-  redis:
-    configmap: |
-      loadmodule /redismodules/redisearch.so
+  auth:
+    password: p@ssw0rd!
+  commonConfiguration: |
+    loadmodule /redismodules/redisearch.so
+  master:
     initContainers:
-      - name: redisearch
-        image: redislabs/redisearch:2.2.0
+      - name: redismodules
+        image: alpine
         command:
           [
             "sh",
             "-c",
-            "cp /usr/lib/redis/modules/redisearch.so /redismodules/redisearch.so",
+            "wget https://redismodules.s3.amazonaws.com/redisearch-oss/redisearch-oss.Linux-buster-x86_64.2.2.0.zip -O /tmp/redisearch-oss.zip &&
+            unzip /tmp/redisearch-oss.zip -d /redismodules/"
+          ]
+        volumeMounts:
+          - mountPath: /redismodules
+            name: redismodules
+    extraVolumes:
+      - name: redismodules
+        emptyDir: {}
+    extraVolumeMounts:
+      - mountPath: /redismodules
+        name: redismodules
+  replica:
+    initContainers:
+      - name: redismodules
+        image: alpine
+        command:
+          [
+            "sh",
+            "-c",
+            "wget https://redismodules.s3.amazonaws.com/redisearch-oss/redisearch-oss.Linux-buster-x86_64.2.2.0.zip -O /tmp/redisearch-oss.zip &&
+            unzip /tmp/redisearch-oss.zip -d /redismodules/"
           ]
         volumeMounts:
           - mountPath: /redismodules


### PR DESCRIPTION
## Jira task - https://cloudentity.atlassian.net/browse/AUT-3538

## BREAKING CHANGE

If upgrading from version 0.15.0-0.15.2 will recreate redis cluster with data loss.

## Description

ACP is not fully compatible with redis open source multi master topology. ACP might randomly fail to connect to redis nodes. Minimum number of nodes in redis-cluster is 3 so we cannot scale it down to 1. We have decided to revert back redis-cluster change to redis master-replica which will result to cluster recreation while upgrading from 0.15.0 - 0.15.2. This does not affect users upgrading from 0.14.x. The issue will be resolved in upcoming ACP release.

## Type of changes

[] Bugfix (non-breaking change which fixes an issue)
[] New feature (non-breaking change which adds functionality)
[] Tests (extending the test suite)
[] Refactor (internal improvement that doesn't change product functionality)
[x] Other (if none of the other choices apply)
