### PR TITLE
[AUT-3741] Added mTLS Ingress in ACP chart

### DIFF
--- a/charts/acp/templates/ingress.yaml
+++ b/charts/acp/templates/ingress.yaml
@@ -1,6 +1,6 @@
-{{- if .Values.ingress.enabled -}}
 {{- $fullName := include "acp.fullname" . -}}
 {{- $svcPort := include "acp.portNumber" . -}}
+{{- if .Values.ingress.enabled -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
@@ -55,4 +55,56 @@ spec:
               servicePort: {{ $svcPort }}
           {{- end }}
     {{- end }}
-  {{- end }}
+{{- end }}
+---
+{{- if .Values.ingressMtls.enabled -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-mtls
+  labels:
+    {{- include "acp.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
+    nginx.ingress.kubernetes.io/auth-tls-secret: {{ .Release.Namespace }}/{{ .Values.ingressMtls.secret.name }}
+    {{- if .Values.tlsDisabled }}
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    {{- else }}
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    {{- end }}
+    nginx.ingress.kubernetes.io/proxy-ssl-ciphers: "EECDH+AESGCM:EDH+AESGCM"
+    nginx.ingress.kubernetes.io/proxy-ssl-protocols: "TLSv1.2"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
+    nginx.ingress.kubernetes.io/ssl-ciphers: "EECDH+AESGCM:EDH+AESGCM"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header X-SSL-CERT $ssl_client_escaped_cert;
+    {{- with .Values.ingress.customAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  tls:
+    - hosts:
+        {{- range .Values.ingressMtls.hosts }}
+        - {{ .host | quote }}
+        {{- end }}
+      secretName: {{ .Values.ingressMtls.secret.name }}
+  rules:
+    {{- range .Values.ingressMtls.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/acp/templates/tls-secrets.yaml
+++ b/charts/acp/templates/tls-secrets.yaml
@@ -25,3 +25,19 @@ data:
   tls.crt: {{ .cert | b64enc }}
   tls.key: {{ .key | b64enc }}
 {{- end }}
+---
+{{- if .Values.ingressMtls.enabled }}
+{{- with .Values.ingressMtls.secret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name }}
+  labels:
+    {{- include "acp.labels" $ | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .cert | b64enc }}
+  tls.key: {{ .key | b64enc }}
+  ca.crt: {{ .caCert | b64enc }}
+{{- end }}
+{{- end }}

--- a/charts/acp/values.yaml
+++ b/charts/acp/values.yaml
@@ -100,6 +100,36 @@ ingress:
   #
   #     -----END RSA PRIVATE KEY-----
 
+ingressMtls:
+  ## Enables mTLS Ingress for ACP
+  ## This is an independent instance from the one above.
+  enabled: false
+
+  ## mTLS Ingress additional custom annotations
+  ##
+  customAnnotations:
+
+  ## mTLS Ingress hostnames with paths
+  ##
+  hosts:
+    - host: mtls.acp.local
+      paths:
+        - path: /
+
+  ## TLS certificates to be created for mTLS Ingress
+  ##
+  secret:
+    name: ingress-mtls
+    cert: |
+      -----BEGIN CERTIFICATE-----
+      -----END CERTIFICATE-----
+    key: |
+      -----BEGIN PRIVATE KEY-----
+      -----END PRIVATE KEY-----
+    caCert: |
+      -----BEGIN CERTIFICATE-----
+      -----END CERTIFICATE-----
+
 
 autoscaling:
   enabled: false

--- a/charts/acp/values.yaml
+++ b/charts/acp/values.yaml
@@ -103,6 +103,7 @@ ingress:
 ingressMtls:
   ## Enables mTLS Ingress for ACP
   ## This is an independent instance from the one above.
+  ##
   enabled: false
 
   ## mTLS Ingress additional custom annotations
@@ -119,13 +120,21 @@ ingressMtls:
   ## TLS certificates to be created for mTLS Ingress
   ##
   secret:
+    ## Name of the Kubernetes secret
+    ##
     name: ingress-mtls
+    ## Domain certificate
+    ##
     cert: |
       -----BEGIN CERTIFICATE-----
       -----END CERTIFICATE-----
+    ## Domain certificate key
+    ##
     key: |
       -----BEGIN PRIVATE KEY-----
       -----END PRIVATE KEY-----
+    ## CA certificate of the domain certificate and client certificates
+    ##
     caCert: |
       -----BEGIN CERTIFICATE-----
       -----END CERTIFICATE-----


### PR DESCRIPTION
## Jira task - [AUT-3741](https://cloudentity.atlassian.net/browse/AUT-3741)

## Description

Added possibility to enable additional Ingress running in mutual TLS (mTLS) mode to the ACP chart.

## Type of changes
<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Tests (extending the test suite)
- [ ] Refactor (internal improvement that doesn't change product functionality)
- [ ] Other (if none of the other choices apply)

## Implementation details

<!--- Describe implementation details if needed -->

## Screenshots (if appropriate):
