### PR TITLE
[AUT-3741] Corrected Ingresses configuration for mTLS

### DIFF
--- a/charts/acp/templates/configmap.yaml
+++ b/charts/acp/templates/configmap.yaml
@@ -10,7 +10,7 @@ data:
     server:
       url: {{ .Values.serverURL }}
       {{- if .Values.ingressMtls.enabled }}
-      mtls_url: "{{ .Values.serverULRMtls }}"
+      mtls_url: "{{ .Values.serverURLMtls }}"
       {{- end }}
       {{- with .Values.certificate.cert }}
       certificate:

--- a/charts/acp/templates/configmap.yaml
+++ b/charts/acp/templates/configmap.yaml
@@ -9,6 +9,9 @@ data:
   config.yaml: |
     server:
       url: {{ .Values.serverURL }}
+      {{- if .Values.ingressMtls.enabled }}
+      mtls_url: "{{ .Values.serverULRMtls }}"
+      {{- end }}
       {{- with .Values.certificate.cert }}
       certificate:
         cert_path: "/tls/tls.crt"

--- a/charts/acp/templates/ingress.yaml
+++ b/charts/acp/templates/ingress.yaml
@@ -68,6 +68,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/auth-tls-verify-client: "optional_no_ca"
+    nginx.ingress.kubernetes.io/auth-tls-verify-depth: "2"
     nginx.ingress.kubernetes.io/auth-tls-secret: {{ .Release.Namespace }}/{{ .Values.ingressMtls.secret.name }}
     {{- if .Values.tlsDisabled }}
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"

--- a/charts/acp/templates/ingress.yaml
+++ b/charts/acp/templates/ingress.yaml
@@ -24,11 +24,8 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
     nginx.ingress.kubernetes.io/ssl-ciphers: "EECDH+AESGCM:EDH+AESGCM"
-    nginx.ingress.kubernetes.io/server-snippet: |
-      ssl_verify_client optional_no_ca;
-      ssl_verify_depth 2;
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      proxy_set_header X-SSL-CERT $ssl_client_escaped_cert;
+      proxy_set_header X-SSL-CERT "";
     {{- with .Values.ingress.customAnnotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -70,7 +67,7 @@ metadata:
     {{- include "acp.labels" . | nindent 4 }}
   annotations:
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: "optional_no_ca"
     nginx.ingress.kubernetes.io/auth-tls-secret: {{ .Release.Namespace }}/{{ .Values.ingressMtls.secret.name }}
     {{- if .Values.tlsDisabled }}
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"

--- a/charts/acp/values.yaml
+++ b/charts/acp/values.yaml
@@ -22,6 +22,10 @@ imagePullSecrets:
 ##
 serverURL: "https://acp.local:8443"
 
+## Public ACP URL for Ingress working in mTLS
+##
+serverULRMtls: "https://mtls.acp.local:8443"
+
 ## String to partially override acp.name
 ##
 # nameOverride: ""

--- a/charts/acp/values.yaml
+++ b/charts/acp/values.yaml
@@ -24,7 +24,7 @@ serverURL: "https://acp.local:8443"
 
 ## Public ACP URL for Ingress working in mTLS
 ##
-serverULRMtls: "https://mtls.acp.local:8443"
+serverURLMtls: "https://mtls.acp.local:8443"
 
 ## String to partially override acp.name
 ##


### PR DESCRIPTION
## Jira task - [AUT-3741](https://cloudentity.atlassian.net/browse/AUT-3741)

## Description

mTLS Ingress for ACP has relaxed requirements for the client certificate now. The new nginx conf:
```
ssl_verify_client                       optional_no_ca;
```

## Type of changes
<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Tests (extending the test suite)
- [ ] Refactor (internal improvement that doesn't change product functionality)
- [ ] Other (if none of the other choices apply)

## Implementation details

<!--- Describe implementation details if needed -->

## Screenshots (if appropriate):
