### PR TITLE
[DEVOPS-1586] Replaced client ca secret type with default opaque

### DIFF
--- a/charts/acp/templates/tls-secrets.yaml
+++ b/charts/acp/templates/tls-secrets.yaml
@@ -25,7 +25,6 @@ metadata:
   name: {{ include "acp.fullname" . }}-client-tls
   labels:
     {{- include "acp.labels" . | nindent 4 }}
-type: kubernetes.io/tls
 data:
   client-ca.crt: {{ .Values.client.rootCa | b64enc }}
 {{- end }}


### PR DESCRIPTION
## Jira task - [PUT_JIRA_LINK_HERE](https://cloudentity.atlassian.net/browse/DEVOPS-1586)

## Description

Removed client ca secret type (default is opaque).

Current setup fails on install with
```
failed to create resource: Secret "acp-client-tls" is invalid: [data[tls.crt]: Required value, data[tls.key]: Required value]                                                                      
```
as tls secret type enforces
```
data:
  tls.crt:
  tls.key: 
```

## Type of changes
<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Tests (extending the test suite)
- [ ] Refactor (internal improvement that doesn't change product functionality)
- [ ] Other (if none of the other choices apply)
