### PR TITLE
Use client root ca (if defined) when running import

### DIFF
--- a/charts/acp/templates/import.yaml
+++ b/charts/acp/templates/import.yaml
@@ -21,9 +21,15 @@ spec:
           configMap:
             name: {{ include "acp.configName" . }}
         - name: tls
-          secret:
-            secretName: {{ include "acp.fullname" . }}-tls
+          projected:
             defaultMode: 384
+            sources:
+            - secret:
+                name: {{ include "acp.fullname" . }}-tls
+            {{- if ((.Values.client).rootCa) }}
+            - secret:
+                name: {{ include "acp.fullname" . }}-client-tls
+            {{- end }}
         - name: import
           configMap:
             name: {{ include "acp.fullname" . }}-import


### PR DESCRIPTION
## Description

This PR fixes an issue where import doesn't work when acp client rootCa is set. 

## Type of changes
<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Tests (extending the test suite)
- [ ] Refactor (internal improvement that doesn't change product functionality)
- [ ] Other (if none of the other choices apply)
