### PR TITLE
[DEVOPS-723] Removed github workflow dependency on lint in publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   acp:
-    needs: lint
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     steps:
@@ -43,7 +42,6 @@ jobs:
         run: jfrog rt u *.tgz acp-helm-charts
 
   openbanking:
-    needs: lint
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     steps:
@@ -60,7 +58,6 @@ jobs:
         run: jfrog rt u *.tgz acp-helm-charts
 
   istio-authorizer:
-    needs: lint
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     steps:


### PR DESCRIPTION
## Jira task - DEVOPS-723

## Description

Removed old, unnecessary dependency on non exiting `lint` job in Publish workflow.

## Type of changes
<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Tests (extending the test suite)
- [ ] Refactor (internal improvement that doesn't change product functionality)
- [ ] Other (if none of the other choices apply)

## Implementation details

<!--- Describe implementation details if needed -->

## Screenshots (if appropriate):
