### PR TITLE
Add a dependency for mailhog, but leave it disabled by default.

### DIFF
--- a/charts/acp/templates/configmap.yaml
+++ b/charts/acp/templates/configmap.yaml
@@ -56,6 +56,10 @@ data:
     features:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.email }}
+    email:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   extraconfig.yaml: |
     {{- with .Values.config.data }}
       {{- toYaml . | nindent 4 }}

--- a/charts/kube-acp-stack/Chart.yaml
+++ b/charts/kube-acp-stack/Chart.yaml
@@ -14,6 +14,10 @@ dependencies:
     version: "7.6.3"
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: redis-cluster.enabled
+  - name: mailhog
+    version: "5.0.7"
+    repository: https://codecentric.github.io/helm-charts
+    condition: mailhog.enabled
   - name: acp
     version: "2.4.1"
     repository: https://charts.cloudentity.io

--- a/charts/kube-acp-stack/values.yaml
+++ b/charts/kube-acp-stack/values.yaml
@@ -12,6 +12,8 @@ cockroachdb:
   enabled: true
   tls:
     enabled: false
+mailhog:
+  enabled: false
 redis-cluster:
   enabled: true
   cluster:


### PR DESCRIPTION

## Description

Adds a dependency on `mailhog`, that is disabled by default.
I have another PR in `acp-on-k8s` to use `mailhog` for email.

## Information for QA
<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->
- [ ] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?

