### PR TITLE
[DEVOPS-2101] Update release start scripts to also set charts app version

### DIFF
--- a/.github/workflows/release-branch.yaml
+++ b/.github/workflows/release-branch.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set ACP version
-        run: sed -i.bak "s/ACP_VERSION ?=.*/ACP_VERSION ?= ${{ env.ACP_VERSION }}/" Makefile && rm Makefile.bak
+        run: sed -i.bak "s/ACP_VERSION ?=.*/ACP_VERSION ?= ${{ env.ACP_VERSION }}/" Makefile && rm -rf Makefile.bak
 
       - name: ACP version in charts
         run: CI=true make bump-acp-version

--- a/tests/scripts/bump-acp-version.sh
+++ b/tests/scripts/bump-acp-version.sh
@@ -17,6 +17,7 @@ bump-acp-version() {
       yq eval -i '.version = strenv(ACP_VERSION)' ./charts/${CHART}/Chart.yaml
       yq eval -i '.dependencies[] |= select(.name == "acp").version = strenv(ACP_VERSION)' ./charts/${CHART}/Chart.yaml
     else
+      yq eval -i '.version = strenv(ACP_VERSION)' ./charts/${CHART}/Chart.yaml
       yq eval -i '.appVersion = strenv(ACP_VERSION)' ./charts/${CHART}/Chart.yaml
     fi
   done


### PR DESCRIPTION
## Jira task - https://cloudentity.atlassian.net/browse/DEVOPS-2101

## Description

Update release start scripts to also set charts app version as it was not set.

## Information for QA
<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->
- [ ] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?
