### PR TITLE
Update nginx annotations

### DIFF
--- a/charts/acp/Chart.yaml
+++ b/charts/acp/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: acp
 description: Cloudentity Authorization Control Plane
 type: application
-version: 2.6.0
+version: 2.6.1-1
 appVersion: "2.6.0"

--- a/charts/acp/templates/ingress.yaml
+++ b/charts/acp/templates/ingress.yaml
@@ -23,11 +23,16 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-ssl-ciphers: "EECDH+AESGCM:EDH+AESGCM"
     nginx.ingress.kubernetes.io/proxy-ssl-protocols: "TLSv1.2"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-ssl-secret: "{{ .Release.Namespace }}/{{ include "acp.fullname" . }}-tls"
+    nginx.ingress.kubernetes.io/proxy-ssl-server-name: "on"
     nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/ssl-ciphers: "EECDH+AESGCM:EDH+AESGCM"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header X-SSL-CERT "";
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"
+    nginx.ingress.kubernetes.io/service-upstream: "true"
     {{- with .Values.ingress.customAnnotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -86,7 +91,7 @@ metadata:
     {{- end }}
     nginx.ingress.kubernetes.io/auth-tls-verify-client: "optional_no_ca"
     nginx.ingress.kubernetes.io/auth-tls-verify-depth: "2"
-    nginx.ingress.kubernetes.io/auth-tls-secret: {{ include "acp.mtls.secrets" . }}
+    nginx.ingress.kubernetes.io/auth-tls-secret: "{{ include "acp.mtls.secrets" . }}"
     {{- if .Values.tlsDisabled }}
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
     {{- else }}
@@ -94,12 +99,17 @@ metadata:
     {{- end }}
     nginx.ingress.kubernetes.io/proxy-ssl-ciphers: "EECDH+AESGCM:EDH+AESGCM"
     nginx.ingress.kubernetes.io/proxy-ssl-protocols: "TLSv1.2"
+    nginx.ingress.kubernetes.io/proxy-ssl-secret: "{{ .Release.Namespace }}/{{ include "acp.fullname" . }}-tls"
+    nginx.ingress.kubernetes.io/proxy-ssl-server-name: "on"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/ssl-ciphers: "EECDH+AESGCM:EDH+AESGCM"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header X-SSL-CERT $ssl_client_escaped_cert;
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"
+    nginx.ingress.kubernetes.io/service-upstream: "true"
     {{- with .Values.ingress.customAnnotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/acp/templates/ingress.yaml
+++ b/charts/acp/templates/ingress.yaml
@@ -30,9 +30,6 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-ciphers: "EECDH+AESGCM:EDH+AESGCM"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header X-SSL-CERT "";
-    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
-    nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"
-    nginx.ingress.kubernetes.io/service-upstream: "true"
     {{- with .Values.ingress.customAnnotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -107,10 +104,7 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-ciphers: "EECDH+AESGCM:EDH+AESGCM"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header X-SSL-CERT $ssl_client_escaped_cert;
-    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
-    nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"
-    nginx.ingress.kubernetes.io/service-upstream: "true"
-    {{- with .Values.ingress.customAnnotations }}
+    {{- with .Values.ingressMtls.customAnnotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:

--- a/charts/acp/templates/ingress.yaml
+++ b/charts/acp/templates/ingress.yaml
@@ -20,12 +20,12 @@ metadata:
     {{- else }}
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     {{- end }}
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
     nginx.ingress.kubernetes.io/proxy-ssl-ciphers: "EECDH+AESGCM:EDH+AESGCM"
     nginx.ingress.kubernetes.io/proxy-ssl-protocols: "TLSv1.2"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-ssl-secret: "{{ .Release.Namespace }}/{{ include "acp.fullname" . }}-tls"
     nginx.ingress.kubernetes.io/proxy-ssl-server-name: "on"
-    nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/ssl-ciphers: "EECDH+AESGCM:EDH+AESGCM"
     nginx.ingress.kubernetes.io/configuration-snippet: |
@@ -94,12 +94,12 @@ metadata:
     {{- else }}
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     {{- end }}
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
     nginx.ingress.kubernetes.io/proxy-ssl-ciphers: "EECDH+AESGCM:EDH+AESGCM"
     nginx.ingress.kubernetes.io/proxy-ssl-protocols: "TLSv1.2"
     nginx.ingress.kubernetes.io/proxy-ssl-secret: "{{ .Release.Namespace }}/{{ include "acp.fullname" . }}-tls"
     nginx.ingress.kubernetes.io/proxy-ssl-server-name: "on"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/ssl-ciphers: "EECDH+AESGCM:EDH+AESGCM"
     nginx.ingress.kubernetes.io/configuration-snippet: |

--- a/charts/acp/values.yaml
+++ b/charts/acp/values.yaml
@@ -91,7 +91,10 @@ ingress:
 
   ## Ingress additional custom annotations
   ##
-  customAnnotations: {}
+  customAnnotations:
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"
+    nginx.ingress.kubernetes.io/service-upstream: "true"
 
   ## Ingress hostnames with paths
   ##
@@ -136,7 +139,10 @@ ingressMtls:
 
   ## mTLS Ingress additional custom annotations
   ##
-  customAnnotations: {}
+  customAnnotations:
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"
+    nginx.ingress.kubernetes.io/service-upstream: "true"
 
   ## mTLS Ingress hostnames with paths
   ##

--- a/charts/kube-acp-stack/Chart.yaml
+++ b/charts/kube-acp-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-acp-stack
 description: kube-acp-stack collects acp charts combined with documentation and scripts to provide easy to operate end-to-end Kubernetes cluster
 type: application
-version: 2.6.0
+version: 2.6.1-1
 sources:
   - https://github.com/cloudentity/acp-helm-charts
 dependencies:
@@ -15,6 +15,6 @@ dependencies:
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: redis-cluster.enabled
   - name: acp
-    version: "2.6.0"
+    version: "2.6.1-1"
     repository: https://charts.cloudentity.io
     condition: acp.enabled

--- a/tests/config/kind.yaml
+++ b/tests/config/kind.yaml
@@ -2,6 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
+    image: kindest/node:v1.24.4@sha256:adfaebada924a26c2c9308edd53c6e33b3d4e453782c0063dc0028bdebaddf98
     extraPortMappings:
 #ACP Ingress controler
       - containerPort: 30443


### PR DESCRIPTION
## Description

Update ingress annotations with the following:

* Enable mod security with owasp by default
* Enable mTLS communication between ingress (nginx) and ACP
* Set downstream to ACP service instead of individual pods

Set kube version in tests to 1.24 as on newer version cockroachdb subchart that we use is failing to install due depreciated APIs.

## Information for QA
<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->
- [ ] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?

## Additional QA Procedures (Optional)

<!--- Describe what QA needs to do if needed -->

## Implementation details

<!--- Describe implementation details if needed -->

## Screenshots (if appropriate):
