### PR TITLE
Upgrade coackroachdb helm chart to version 8.1.7, for compatibility with Kubernetes 1.25+

### DIFF
--- a/charts/kube-acp-stack/Chart.yaml
+++ b/charts/kube-acp-stack/Chart.yaml
@@ -7,7 +7,7 @@ sources:
   - https://github.com/cloudentity/acp-helm-charts
 dependencies:
   - name: cockroachdb
-    version: "7.0.0"
+    version: "8.1.7"
     repository: https://charts.cockroachdb.com
     condition: cockroachdb.enabled
   - name: redis-cluster


### PR DESCRIPTION
## Description

Attempting to deploy the ACP stack on kind v1.25+, yields the following errors from the `cockroachdb` chart:
```
  helm upgrade acp acp/kube-acp-stack \
                  --values ./values/kube-acp-stack.yaml \
                  --namespace acp-system \
                  --timeout 30m \
                  --install
  Release "acp" does not exist. Installing it now.
  Error: unable to build kubernetes objects from release manifest: [resource mapping not found for name: "acp-cockroachdb-budget" namespace: "acp-system" from "": no matches for kind "PodDisruptionBudget" in version "policy/v1beta1"
  ensure CRDs are installed first, resource mapping not found for name: "acp-cockroachdb-rotate-self-signer-client" namespace: "acp-system" from "": no matches for kind "CronJob" in version "batch/v1beta1"
  ensure CRDs are installed first]
  make: *** [install-acp-stack] Error 1
```
On earlier kind releases, these generate deprecation warnings:
```
W1003 17:04:08.939807   11242 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
W1003 17:04:08.965993   11242 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
W1003 17:04:08.996090   11242 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
W1003 17:04:09.206890   11242 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
```
These issues can be fixed by adopting the currently release `8.1.7` of the cockroachdb helm chart.

## Information for QA
<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->
- [ ] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?

## Additional QA Procedures (Optional)
