### PR TITLE
[AUT-7310] - Introducing keydb as a replacement for redis-cluster

### DIFF
--- a/charts/acp/templates/configmap.yaml
+++ b/charts/acp/templates/configmap.yaml
@@ -45,8 +45,8 @@ data:
       {{- else }}
       enabled: true
       addrs:
-      - "{{ .Release.Name }}-redis-cluster-headless:6379"
-      - "{{ .Release.Name }}-redis-cluster-headless:6379"
+      - "{{ .Release.Name }}-keydb-headless:6379"
+      - "{{ .Release.Name }}-keydb-headless:6379"
       {{- end }}
     {{- if .Values.fission.enabled }}
     faas:

--- a/charts/kube-acp-stack/Chart.yaml
+++ b/charts/kube-acp-stack/Chart.yaml
@@ -18,3 +18,7 @@ dependencies:
     version: "2.7.1-2"
     repository: https://charts.cloudentity.io
     condition: acp.enabled
+  - name: keydb
+    version: "0.42.1"
+    repository: https://enapter.github.io/charts/
+    condition: keydb.enabled

--- a/charts/kube-acp-stack/values.yaml
+++ b/charts/kube-acp-stack/values.yaml
@@ -40,3 +40,22 @@ redis-cluster:
     extraVolumeMounts:
       - mountPath: /redismodules
         name: redismodules
+keydb:
+  enabled: true
+  extraInitContainers:
+    - name: redismodules
+      image: alpine
+      command:
+        [
+          "sh",
+          "-c",
+          "wget https://redismodules.s3.amazonaws.com/redisearch-oss/redisearch-oss.Linux-buster-x86_64.2.2.0.zip -O /tmp/redisearch-oss.zip &&
+          unzip /tmp/redisearch-oss.zip -d /data/"
+        ]
+      volumeMounts:
+        - mountPath: /data
+          name: keydb-data
+  configExtraArgs:
+    - loadmodule: "/data/redisearch.so"
+  persistentVolume:
+    size: 10Gi


### PR DESCRIPTION
## Jira task - [PUT_JIRA_LINK_HERE](https://cloudentity.atlassian.net/browse/AUT-7130)

## BREAKING CHANGE -
This change can break the login to ACP UI as KeyDB is now introduced instead of redis-cluster.

## Description
KeyDB is introduced in acp-stack and will replace redis-cluster that is used for session management.

## Information for QA
<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->
- [X ] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?

## Additional QA Procedures (Optional)

Verify acc-stack gets installed and configured correctly. Make sure session management works fine with keydb.

## Implementation details

<!--- Describe implementation details if needed -->

## Screenshots (if appropriate):
