### PR TITLE
[DEVOPS-723] Setup of direct set values for timescaledb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ clean: delete-cluster clean-helm
 # auxiliaries
 create-cluster:
 	kind create cluster \
-		--name chart-test \
+		--name acp-helm-charts \
 		--config tests/config/kind.yaml
 	kubectl create namespace ${NAMESPACE}
 	kubectl create secret docker-registry docker.cloudentity.io \
@@ -79,7 +79,7 @@ clean-helm:
 	rm --recursive --force .kube-acp-stack-test
 
 delete-cluster:
-	kind delete cluster --name chart-test
+	kind delete cluster --name acp-helm-charts
 
 docker:
 	docker build --tag cloudentity/helm-tools - < Dockerfile

--- a/charts/acp/templates/configmap.yaml
+++ b/charts/acp/templates/configmap.yaml
@@ -48,6 +48,14 @@ data:
       - "{{ .Release.Name }}-redis-cluster-headless:6379"
       - "{{ .Release.Name }}-redis-cluster-headless:6379"
       {{- end }}
+    {{- if .Values.timescale.enabled }}
+    timescale:
+      {{- with .Values.timescale }}
+        {{- toYaml . | nindent 6 }}
+      {{- else }}
+      enabled: true
+      {{- end }}
+    {{- end }}
     {{- if .Values.fission.enabled }}
     faas:
       provider: {{ .Values.fission.provider }}

--- a/charts/acp/values.yaml
+++ b/charts/acp/values.yaml
@@ -445,15 +445,24 @@ certificate:
 
 ## SQL client
 ## The data should match acp configuration options
-## https://docs.operations.cloudentity.com/reference/acp-configuration/
+## https://cloudentity.com/developers/deployment-and-operations/reference/configuration-reference/
 ##
 # sql: {}
 
 ## Redis client
 ## The data should match acp configuration options
-## https://docs.operations.cloudentity.com/reference/acp-configuration/
+## https://cloudentity.com/developers/deployment-and-operations/reference/configuration-reference/
 ##
 # redis: {}
+
+## Timescaledb client
+## The data should match acp configuration options
+## https://cloudentity.com/developers/deployment-and-operations/reference/configuration-reference/
+##
+timescale:
+  ## Enables timescale for ACP
+  ##
+  enabled: false
 
 ## Workers chart configuration
 ## Worker nodes are used to create seperate ACP deployment for asynchronous jobs handling


### PR DESCRIPTION
## Jira task - https://cloudentity.atlassian.net/browse/DEVOPS-723

## Implementation details (internal)

Allow setup of timescale values like:
```yaml
acp:
  enabled: true
  secretConfig:
    data:
      redis:
        password: p@ssw0rd!
  timescale:
      enabled: true
      url: postgres://acp:PaSsW0rD@timescaledb.acp-db.svc.cluster.local/acpdb
      migrations:
          path: ./migrations/timescale
          timeout: 1m0s
```

instead of old way

```yaml
acp:
  enabled: true
  secretConfig:
    data:
      redis:
        password: p@ssw0rd!
  config:
    data:
      redis:
        redis_search: true
      timescale:
          enabled: true
          url: postgres://acp:PaSsW0rD@timescaledb.acp-db.svc.cluster.local/acpdb
          migrations:
              path: ./migrations/timescale
              timeout: 1m0s
```