### PR TITLE
[AUT-8465] Add posibility to annotate acp service

### DIFF
--- a/charts/acp/templates/service.yaml
+++ b/charts/acp/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "acp.fullname" . }}
   labels:
     {{- include "acp.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/acp/values.yaml
+++ b/charts/acp/values.yaml
@@ -522,7 +522,7 @@ workers:
 
     ## Service annotations
     ##
-    annotations: {}
+    # annotations: {}
 
   ## ServiceMonitor configuration
   ##

--- a/charts/acp/values.yaml
+++ b/charts/acp/values.yaml
@@ -520,6 +520,10 @@ workers:
     ##
     type: ClusterIP
 
+    ## Service annotations
+    ##
+    annotations: {}
+
   ## ServiceMonitor configuration
   ##
   serviceMonitor:


### PR DESCRIPTION
## Jira task - https://cloudentity.atlassian.net/browse/AUT-8465

## Implementation details (internal)

Add the possibility to annotate ACP service.
This is introduced as part of Contour testing as potential ingress, which requires specific annotation on service.