### PR TITLE
[DEVOPS-2588] define startupProbe, readinessProbe, livenessProbe

### DIFF
--- a/charts/acp/templates/deployment.yaml
+++ b/charts/acp/templates/deployment.yaml
@@ -82,20 +82,10 @@ spec:
             - name: grpc
               containerPort: 9443
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /alive
-              {{- if .Values.tlsDisabled }}
-              scheme: HTTP
-              {{- else }}
-              scheme: HTTPS
-              {{- end }}
-              port: {{ include "acp.portNumber" . }}
-            initialDelaySeconds: 3
-            failureThreshold: 10
-            periodSeconds: 10
-            timeoutSeconds: 10
           startupProbe:
+          {{- if .Values.customStartupProbe }}
+            {{ toYaml .Values.customStartupProbe | nindent 12 }}
+          {{- else }}
             httpGet:
               path: /alive
               {{- if .Values.tlsDisabled }}
@@ -107,7 +97,11 @@ spec:
             failureThreshold: 10
             periodSeconds: 10
             timeoutSeconds: 10
+          {{- end }}
           readinessProbe:
+          {{- if .Values.customReadinessProbe }}
+            {{ toYaml .Values.customReadinessProbe | nindent 12 }}
+          {{- else }}
             httpGet:
               path: /alive
               {{- if .Values.tlsDisabled }}
@@ -120,6 +114,24 @@ spec:
             failureThreshold: 3
             periodSeconds: 10
             timeoutSeconds: 10
+          {{- end }}
+          livenessProbe:
+          {{- if .Values.customLivenessProbe }}
+            {{ toYaml .Values.customLivenessProbe | nindent 12 }}
+          {{- else }}
+            httpGet:
+              path: /alive
+              {{- if .Values.tlsDisabled }}
+              scheme: HTTP
+              {{- else }}
+              scheme: HTTPS
+              {{- end }}
+              port: {{ include "acp.portNumber" . }}
+            initialDelaySeconds: 3
+            failureThreshold: 10
+            periodSeconds: 10
+            timeoutSeconds: 10
+          {{- end }}
           volumeMounts:
             - mountPath: /data
               name: data

--- a/charts/acp/templates/fission.yaml
+++ b/charts/acp/templates/fission.yaml
@@ -43,7 +43,7 @@ spec:
           {{- end }}
           startupProbe:
           {{- if .Values.fission.node.customStartupProbe }}
-            {{ toYaml .Values.fission.node.customLivenessProbe | nindent 12 }}
+            {{ toYaml .Values.fission.node.customStartupProbe | nindent 12 }}
           {{- else }}
             failureThreshold: 10
             periodSeconds: 10
@@ -118,7 +118,7 @@ spec:
           {{- end }}
           startupProbe:
           {{- if .Values.fission.rego.customStartupProbe }}
-            {{ toYaml .Values.fission.rego.customLivenessProbe | nindent 12 }}
+            {{ toYaml .Values.fission.rego.customStartupProbe | nindent 12 }}
           {{- else }}
             failureThreshold: 10
             periodSeconds: 10

--- a/charts/acp/templates/fission.yaml
+++ b/charts/acp/templates/fission.yaml
@@ -41,6 +41,28 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          startupProbe:
+            failureThreshold: 10
+            periodSeconds: 10
+            httpGet:
+              path: /healthz
+              port: 8888
+          readinessProbe:
+            failureThreshold: 15
+            initialDelaySeconds: 5
+            periodSeconds: 1
+            timeoutSeconds: 1
+            httpGet:
+              path: /healthz
+              port: 8888
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 0
+            httpGet:
+              path: /healthz
+              port: 8888
       {{- with .Values.fission.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -82,6 +104,28 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          startupProbe:
+            failureThreshold: 10
+            periodSeconds: 10
+            httpGet:
+              path: /healthz
+              port: 8888
+          readinessProbe:
+            failureThreshold: 15
+            initialDelaySeconds: 5
+            periodSeconds: 1
+            timeoutSeconds: 1
+            httpGet:
+              path: /healthz
+              port: 8888
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 0
+            httpGet:
+              path: /healthz
+              port: 8888
       {{- with .Values.fission.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/charts/acp/templates/fission.yaml
+++ b/charts/acp/templates/fission.yaml
@@ -42,20 +42,29 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           startupProbe:
+          {{- if .Values.fission.customStartupProbe }}
+            {{ toYaml .Values.fission.customLivenessProbe | nindent 12 }}
+          {{- else }}
             failureThreshold: 10
             periodSeconds: 10
             httpGet:
               path: /healthz
               port: 8888
           readinessProbe:
-            failureThreshold: 15
-            initialDelaySeconds: 5
-            periodSeconds: 1
-            timeoutSeconds: 1
+          {{- if .Values.fission.customReadinessProbe }}
+            {{ toYaml .Values.fission.customReadinessProbe | nindent 12 }}
+          {{- else }}
+            failureThreshold: 3
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 0
             httpGet:
               path: /healthz
               port: 8888
           livenessProbe:
+          {{- if .Values.fission.customLivenessProbe }}
+            {{ toYaml .Values.fission.customLivenessProbe | nindent 12 }}
+          {{- else }}
             failureThreshold: 3
             initialDelaySeconds: 3
             periodSeconds: 10

--- a/charts/acp/templates/fission.yaml
+++ b/charts/acp/templates/fission.yaml
@@ -42,28 +42,30 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           startupProbe:
-          {{- if .Values.fission.customStartupProbe }}
-            {{ toYaml .Values.fission.customLivenessProbe | nindent 12 }}
+          {{- if .Values.fission.node.customStartupProbe }}
+            {{ toYaml .Values.fission.node.customLivenessProbe | nindent 12 }}
           {{- else }}
             failureThreshold: 10
             periodSeconds: 10
             httpGet:
               path: /healthz
               port: 8888
+          {{- end }}
           readinessProbe:
-          {{- if .Values.fission.customReadinessProbe }}
-            {{ toYaml .Values.fission.customReadinessProbe | nindent 12 }}
+          {{- if .Values.fission.node.customReadinessProbe }}
+            {{ toYaml .Values.fission.node.customReadinessProbe | nindent 12 }}
           {{- else }}
-            failureThreshold: 3
-            initialDelaySeconds: 3
-            periodSeconds: 10
-            timeoutSeconds: 0
+            failureThreshold: 10
+            initialDelaySeconds: 5
+            periodSeconds: 1
+            timeoutSeconds: 1
             httpGet:
               path: /healthz
               port: 8888
+          {{- end }}
           livenessProbe:
-          {{- if .Values.fission.customLivenessProbe }}
-            {{ toYaml .Values.fission.customLivenessProbe | nindent 12 }}
+          {{- if .Values.fission.node.customLivenessProbe }}
+            {{ toYaml .Values.fission.node.customLivenessProbe | nindent 12 }}
           {{- else }}
             failureThreshold: 3
             initialDelaySeconds: 3
@@ -72,6 +74,7 @@ spec:
             httpGet:
               path: /healthz
               port: 8888
+          {{- end }}
       {{- with .Values.fission.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -114,20 +117,31 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           startupProbe:
+          {{- if .Values.fission.rego.customStartupProbe }}
+            {{ toYaml .Values.fission.rego.customLivenessProbe | nindent 12 }}
+          {{- else }}
             failureThreshold: 10
             periodSeconds: 10
             httpGet:
               path: /healthz
               port: 8888
+          {{- end }}
           readinessProbe:
-            failureThreshold: 15
+          {{- if .Values.fission.rego.customReadinessProbe }}
+            {{ toYaml .Values.fission.rego.customReadinessProbe | nindent 12 }}
+          {{- else }}
+            failureThreshold: 10
             initialDelaySeconds: 5
             periodSeconds: 1
             timeoutSeconds: 1
             httpGet:
               path: /healthz
               port: 8888
+          {{- end }}
           livenessProbe:
+          {{- if .Values.fission.rego.customLivenessProbe }}
+            {{ toYaml .Values.fission.rego.customLivenessProbe | nindent 12 }}
+          {{- else }}
             failureThreshold: 3
             initialDelaySeconds: 3
             periodSeconds: 10
@@ -135,6 +149,7 @@ spec:
             httpGet:
               path: /healthz
               port: 8888
+          {{- end }}
       {{- with .Values.fission.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/charts/acp/values.yaml
+++ b/charts/acp/values.yaml
@@ -228,6 +228,39 @@ replicaCount: 1
 ##
 # podAnnotations: {}
 
+## Custom Startup Probe
+##
+customStartupProbe: {}
+  # failureThreshold: 10
+  # periodSeconds: 10
+  # timeoutSeconds: 10
+  # httpGet:
+  #   path: /alive
+  #   scheme: HTTPS
+  #   port: 8443
+
+## Custom Liveness Probe
+customLivenessProbe: {}
+  # failureThreshold: 10
+  # initialDelaySeconds: 3
+  # periodSeconds: 10
+  # timeoutSeconds: 10
+  # httpGet:
+  #   path: /alive
+  #   scheme: HTTPS
+  #   port: 8443
+
+## Custom Readiness Probe
+customReadinessProbe: {}
+  # failureThreshold: 3
+  # initialDelaySeconds: 5
+  # periodSeconds: 10
+  # timeoutSeconds: 10
+  # httpGet:
+  #   path: /alive
+  #   scheme: HTTPS
+  #   port: 8443
+
 ## ACP resource requests and limits
 ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##
@@ -688,7 +721,6 @@ fission:
       # httpGet:
       #   path: /healthz
       #   port: 8888
-
 
   ## Custom rego env configuration
   ##

--- a/charts/acp/values.yaml
+++ b/charts/acp/values.yaml
@@ -564,7 +564,7 @@ workers:
 fission:
   ## Enables the Fission for ACP
   ##
-  enabled: true
+  enabled: false
 
   ## Define provider mode
   ##

--- a/charts/acp/values.yaml
+++ b/charts/acp/values.yaml
@@ -662,7 +662,7 @@ fission:
   ##
   node:
     ## Custom Startup Probe
-    customStrtupProbe: {}
+    customStartupProbe: {}
       # failureThreshold: 10
       # periodSeconds: 10
       # httpGet:
@@ -694,7 +694,7 @@ fission:
   ##
   rego:
     ## Custom Startup Probe
-    customStrtupProbe: {}
+    customStartupProbe: {}
       # failureThreshold: 10
       # periodSeconds: 10
       # httpGet:

--- a/charts/acp/values.yaml
+++ b/charts/acp/values.yaml
@@ -676,7 +676,7 @@ fission:
     #   path: /healthz
     #   port: 8888
 
-  ## Custom Rediness Probe
+  ## Custom Readiness Probe
   customReadinessProbe: {}
     # failureThreshold: 15
     # initialDelaySeconds: 5

--- a/charts/acp/values.yaml
+++ b/charts/acp/values.yaml
@@ -564,7 +564,7 @@ workers:
 fission:
   ## Enables the Fission for ACP
   ##
-  enabled: false
+  enabled: true
 
   ## Define provider mode
   ##
@@ -658,30 +658,65 @@ fission:
   ##
   idleTimeout: 3m0s
 
-  ## Custom Startup Probe
-  customStrtupProbe: {}
-    # failureThreshold: 10
-    # periodSeconds: 10
-    # httpGet:
-    #   path: /healthz
-    #   port: 8888
+  ## Custom node env configuration
+  ##
+  node:
+    ## Custom Startup Probe
+    customStrtupProbe: {}
+      # failureThreshold: 10
+      # periodSeconds: 10
+      # httpGet:
+      #   path: /healthz
+      #   port: 8888
 
-  ## Custom Liveness Probe
-  customLivenessProbe: {}
-    # failureThreshold: 3
-    # initialDelaySeconds: 3
-    # periodSeconds: 10
-    # timeoutSeconds: 0
-    # httpGet:
-    #   path: /healthz
-    #   port: 8888
+    ## Custom Liveness Probe
+    customLivenessProbe: {}
+      # failureThreshold: 3
+      # initialDelaySeconds: 3
+      # periodSeconds: 10
+      # timeoutSeconds: 0
+      # httpGet:
+      #   path: /healthz
+      #   port: 8888
 
-  ## Custom Readiness Probe
-  customReadinessProbe: {}
-    # failureThreshold: 15
-    # initialDelaySeconds: 5
-    # periodSeconds: 1
-    # timeoutSeconds: 1
-    # httpGet:
-    #   path: /healthz
-    #   port: 8888
+    ## Custom Readiness Probe
+    customReadinessProbe: {}
+      # failureThreshold: 15
+      # initialDelaySeconds: 5
+      # periodSeconds: 1
+      # timeoutSeconds: 1
+      # httpGet:
+      #   path: /healthz
+      #   port: 8888
+
+
+  ## Custom rego env configuration
+  ##
+  rego:
+    ## Custom Startup Probe
+    customStrtupProbe: {}
+      # failureThreshold: 10
+      # periodSeconds: 10
+      # httpGet:
+      #   path: /healthz
+      #   port: 8888
+
+    ## Custom Liveness Probe
+    customLivenessProbe: {}
+      # failureThreshold: 3
+      # initialDelaySeconds: 3
+      # periodSeconds: 10
+      # timeoutSeconds: 0
+      # httpGet:
+      #   path: /healthz
+      #   port: 8888
+
+    ## Custom Readiness Probe
+    customReadinessProbe: {}
+      # failureThreshold: 15
+      # initialDelaySeconds: 5
+      # periodSeconds: 1
+      # timeoutSeconds: 1
+      # httpGet:
+      #   path: /healthz
+      #   port: 8888

--- a/charts/acp/values.yaml
+++ b/charts/acp/values.yaml
@@ -591,7 +591,7 @@ fission:
     runAsUser: 65535
     runAsGroup: 65535
     runAsNonRoot: true
-  
+
   ## Container security context
   ##
   containerSecurityContext:

--- a/charts/acp/values.yaml
+++ b/charts/acp/values.yaml
@@ -657,3 +657,31 @@ fission:
   ## Fission function idle timeout
   ##
   idleTimeout: 3m0s
+
+  ## Custom Startup Probe
+  customStrtupProbe: {}
+    # failureThreshold: 10
+    # periodSeconds: 10
+    # httpGet:
+    #   path: /healthz
+    #   port: 8888
+
+  ## Custom Liveness Probe
+  customLivenessProbe: {}
+    # failureThreshold: 3
+    # initialDelaySeconds: 3
+    # periodSeconds: 10
+    # timeoutSeconds: 0
+    # httpGet:
+    #   path: /healthz
+    #   port: 8888
+
+  ## Custom Rediness Probe
+  customReadinessProbe: {}
+    # failureThreshold: 15
+    # initialDelaySeconds: 5
+    # periodSeconds: 1
+    # timeoutSeconds: 1
+    # httpGet:
+    #   path: /healthz
+    #   port: 8888


### PR DESCRIPTION
## https://cloudentity.atlassian.net/browse/DEVOPS-2588


## Release Notes Description (public)

## Implementation details (internal)

- define startupProbe, readinessProbe, livenessProbe:
![Screenshot 2023-07-13 at 10 34 34](https://github.com/cloudentity/acp-helm-charts/assets/68942146/cc1421b3-a2ef-444a-a7f1-85f9c20d8b34)


<!--- Describe technical implementation details for peer reviewers -->

## Information for QA

<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->

- [x] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?

## Additional QA Procedures (Optional)
1. deploy ACP stack from helm charts: 
- check if startup/liveness/readiness probes are available
- configure custom startup/liveness/readiness probes
2. deploy the fission component
- check if startup/liveness/readiness probes are available
- configure custom startup/liveness/readiness probes

## Screenshots (if appropriate):
