### PR TITLE
[DEVOPS-2667] Change acp deployment to restrict seccomp strict by default

### DIFF
--- a/charts/acp/Chart.yaml
+++ b/charts/acp/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: acp
 description: Cloudentity Authorization Control Plane
 type: application
-version: 2.18.0
+version: 2.18.1-1
 appVersion: "2.18.0"

--- a/charts/acp/values.yaml
+++ b/charts/acp/values.yaml
@@ -294,6 +294,8 @@ resources: {}
 podSecurityContext:
   fsGroup: 65535
   runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
 
 ## Container security context
 ##

--- a/charts/kube-acp-stack/Chart.yaml
+++ b/charts/kube-acp-stack/Chart.yaml
@@ -19,6 +19,6 @@ dependencies:
     repository: https://charts.timescale.com
     condition: timescaledb-single.enabled
   - name: acp
-    version: "2.18.0"
+    version: "2.18.1-1"
     repository: https://charts.cloudentity.io
     condition: acp.enabled

--- a/charts/kube-acp-stack/Chart.yaml
+++ b/charts/kube-acp-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-acp-stack
 description: kube-acp-stack collects acp charts combined with documentation and scripts to provide easy to operate end-to-end Kubernetes cluster
 type: application
-version: 2.18.0
+version: 2.18.1-1
 sources:
   - https://github.com/cloudentity/acp-helm-charts
 dependencies:


### PR DESCRIPTION
## Jira task - https://cloudentity.atlassian.net/browse/DEVOPS-2667

## Implementation details (internal)

Change acp deployment to restrict seccomp strict by default based on kyverno findings https://kyverno.io/policies/pod-security/restricted/restrict-seccomp-strict/restrict-seccomp-strict/
