### PR TITLE
[DEVOPS-2622] Add possibility to set container security context for acp-cd and set default values

### DIFF
--- a/charts/acp-cd/Chart.yaml
+++ b/charts/acp-cd/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: acp-cd
 description: Cloudentity ACP continuous Delivery
 type: application
-version: 2.19.0
+version: 2.19.1-1
 appVersion: "2.19.0"

--- a/charts/acp-cd/templates/import.yaml
+++ b/charts/acp-cd/templates/import.yaml
@@ -95,6 +95,8 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/acp-cd/values.yaml
+++ b/charts/acp-cd/values.yaml
@@ -77,6 +77,14 @@ podSecurityContext:
   runAsNonRoot: true
   runAsUser: 1000
 
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
 ## Cert-manager configuration
 ##
 certManager:


### PR DESCRIPTION
## Jira task - https://cloudentity.atlassian.net/browse/DEVOPS-2757


## Release Notes Description (public)

Add the possibility to set container security context for the acp-cd chart and set default values.

## Implementation details (internal)

Add possibility to set container security context for acp-cd and set default values in order to comply with security standards.