### PR TITLE
[AUT-10826] Istio authorizer cluster roles adjustments

### DIFF
--- a/charts/istio-authorizer/Chart.yaml
+++ b/charts/istio-authorizer/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: istio-authorizer
 description: A Helm chart for istio-authorizer
 type: application
-version: 2.21.0
-appVersion: "2.21.0"
+version: 2.21.1
+appVersion: "2.21.1"

--- a/charts/istio-authorizer/Chart.yaml
+++ b/charts/istio-authorizer/Chart.yaml
@@ -3,4 +3,4 @@ name: istio-authorizer
 description: A Helm chart for istio-authorizer
 type: application
 version: 2.21.1
-appVersion: "2.21.1"
+appVersion: "2.21.0"

--- a/charts/istio-authorizer/templates/clusterrole.yaml
+++ b/charts/istio-authorizer/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.discovery.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -21,3 +22,4 @@ rules:
   - "deployments"
   verbs:
   - "list"
+{{- end }}

--- a/charts/istio-authorizer/templates/clusterrolebinding.yaml
+++ b/charts/istio-authorizer/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.discovery.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -17,23 +18,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "istio-authorizer.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ include "istio-authorizer.serviceAccountName" . }}-auth-delegator
-  namespace: default
-  labels:
-    {{- include "istio-authorizer.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:auth-delegator
-subjects:
-- kind: ServiceAccount
-  name: {{ include "istio-authorizer.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+{{- end }}


### PR DESCRIPTION
## Jira task - [PUT_JIRA_LINK_HERE](https://cloudentity.atlassian.net/browse/AUT-10826)

## Release Notes Description (public)

Changes in the istio authorizer:

Remove system:auth-delegator role as it's no longer required.
Apply ClusterRole for scanning namespaces and deployments only if discovery is enabled.

## Implementation details (internal)

<!--- Describe technical implementation details for peer reviewers -->

## Information for QA

<!-- [Place an '[X]' (no spaces) in all applicable fields.] -->

- [ ] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?

## Additional QA Procedures (Optional)

<!--- Describe what QA needs to do if needed -->

## Screenshots (if appropriate):
