### PR TITLE
Bump acp version to 2.25.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ HELM_CHARTS = acp-cd,acp,istio-authorizer,kube-acp-stack
 ISTIO_VERSION ?= 1.13.3
 
 # ACP helm chart version
-ACP_VERSION ?= 2.24.0
+ACP_VERSION ?= 2.25.0
 export ACP_VERSION
 
 ### TARGETS ###

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ NAMESPACE ?= acp-system
 HELM_CHARTS = acp-cd,acp,istio-authorizer,kube-acp-stack
 
 # istio version
-ISTIO_VERSION ?= 1.13.3
+ISTIO_VERSION ?= 1.26.0
 
 # ACP helm chart version
 ACP_VERSION ?= 2.25.0

--- a/charts/acp-cd/Chart.yaml
+++ b/charts/acp-cd/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: acp-cd
 description: Cloudentity ACP continuous Delivery
 type: application
-version: 2.24.0
-appVersion: "2.24.0"
+version: 2.25.0
+appVersion: "2.25.0"

--- a/charts/acp/Chart.yaml
+++ b/charts/acp/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: acp
 description: Cloudentity Authorization Control Plane
 type: application
-version: 2.24.1
-appVersion: "2.24.0"
+version: 2.25.0
+appVersion: "2.25.0"

--- a/charts/istio-authorizer/Chart.yaml
+++ b/charts/istio-authorizer/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: istio-authorizer
 description: A Helm chart for istio-authorizer
 type: application
-version: 2.24.0
-appVersion: "2.24.0"
+version: 2.25.0
+appVersion: "2.25.0"

--- a/charts/kube-acp-stack/Chart.yaml
+++ b/charts/kube-acp-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-acp-stack
 description: kube-acp-stack collects acp charts combined with documentation and scripts to provide easy to operate end-to-end Kubernetes cluster
 type: application
-version: 2.24.1
+version: 2.25.0
 sources:
   - https://github.com/cloudentity/acp-helm-charts
 dependencies:
@@ -19,6 +19,6 @@ dependencies:
     repository: https://charts.timescale.com
     condition: timescaledb-single.enabled
   - name: acp
-    version: "2.24.1"
+    version: "2.25.0"
     repository: https://charts.cloudentity.io
     condition: acp.enabled

--- a/charts/kube-acp-stack/Chart.yaml
+++ b/charts/kube-acp-stack/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
     repository: https://charts.cockroachdb.com
     condition: cockroachdb.enabled
   - name: redis-cluster
-    version: "7.6.4"
+    version: "11.5.4"
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: redis-cluster.enabled
   - name: timescaledb-single

--- a/charts/kube-acp-stack/Chart.yaml
+++ b/charts/kube-acp-stack/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
     repository: https://charts.cockroachdb.com
     condition: cockroachdb.enabled
   - name: redis-cluster
-    version: "11.5.4"
+    version: "7.6.4"
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: redis-cluster.enabled
   - name: timescaledb-single

--- a/charts/kube-acp-stack/values.yaml
+++ b/charts/kube-acp-stack/values.yaml
@@ -44,7 +44,7 @@ redis-cluster:
               ARCH="amd64"
             fi
 
-            wget https://cloudentity-redisearch.s3.amazonaws.com/redisearch-oss-coord-v2.6.28-$ARCH.so -O /redismodules/redisearch.so
+            wget https://cloudentity-redisearch.s3.amazonaws.com/redisearch-oss-coord-v2.10.14-$ARCH.so -O /redismodules/redisearch.so
             chmod +x /redismodules/redisearch.so
         volumeMounts:
           - mountPath: /redismodules

--- a/charts/kube-acp-stack/values.yaml
+++ b/charts/kube-acp-stack/values.yaml
@@ -36,7 +36,7 @@ redis-cluster:
         command: [
           "sh",
           "-c",
-          "wget https://cloudentity-redisearch.s3.amazonaws.com/redisearch-oss-coord-v2.6.13-amd64.so -O /redismodules/redisearch.so &&
+          "wget https://cloudentity-redisearch.s3.amazonaws.com/redisearch-oss-coord-v2.6.28-amd64.so -O /redismodules/redisearch.so &&
           chmod +x /redismodules/redisearch.so"
         ]
         volumeMounts:

--- a/charts/kube-acp-stack/values.yaml
+++ b/charts/kube-acp-stack/values.yaml
@@ -33,12 +33,19 @@ redis-cluster:
     initContainers:
       - name: redismodules
         image: alpine
-        command: [
-          "sh",
-          "-c",
-          "wget https://cloudentity-redisearch.s3.amazonaws.com/redisearch-oss-coord-v2.6.28-amd64.so -O /redismodules/redisearch.so &&
-          chmod +x /redismodules/redisearch.so"
-        ]
+        command:
+          - sh
+          - -c
+          - |
+            ARCH=$(apk --print-arch)
+            if [[ "$ARCH" == "aarch64" ]]; then
+              ARCH="arm64"
+            else
+              ARCH="amd64"
+            fi
+
+            wget https://cloudentity-redisearch.s3.amazonaws.com/redisearch-oss-coord-v2.6.28-$ARCH.so -O /redismodules/redisearch.so
+            chmod +x /redismodules/redisearch.so
         volumeMounts:
           - mountPath: /redismodules
             name: redismodules

--- a/tests/config/kind.yaml
+++ b/tests/config/kind.yaml
@@ -2,7 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.24.4@sha256:adfaebada924a26c2c9308edd53c6e33b3d4e453782c0063dc0028bdebaddf98
+    image: kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f
     extraPortMappings:
 #ACP Ingress controler
       - containerPort: 30443


### PR DESCRIPTION
- release acp 2.25.0

- it looks like PR is green but we need to wait for @jkotiuk 's task to bump redis https://secureauth.atlassian.net/browse/AUT-12336
- some additive changes needed in configuration in order to have stable stack with bumped redis. For sure Kuba knows the details :) 