### PR TITLE
DEVOPS-8110: refactor: migrate helm chart publish workflow to reusable action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,90 +1,70 @@
-name: Publish
+name: Build & Publish Helm Chart
+
 on:
   push:
     branches:
-      - "master"
+      - master
     paths:
       - "**/Chart.yaml"
-  pull_request:
 
 jobs:
   acp:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Helm package charts/acp
-        run: helm package charts/acp
-
-      - uses: jfrog/setup-jfrog-cli@v1
-        env:
-          JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_SECRET_1 }}
-
-      - name: Publish
-        run: jfrog rt u *.tgz acp-helm-charts
+      - name: Publish ACP Chart
+        uses: SecureAuthCorp/github-actions/helm/helm-chart-publish@main
+        with:
+          chart-path: charts/acp
+          jf-token: ${{ secrets.ARTIFACTORY_PASSWORD }}
 
   acp-cd:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Helm package charts/acp-cd
-        run: helm package charts/acp-cd
-
-      - uses: jfrog/setup-jfrog-cli@v1
-        env:
-          JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_SECRET_1 }}
-
-      - name: Publish
-        run: jfrog rt u *.tgz acp-helm-charts
+      - name: Publish ACP CD Chart
+        uses: SecureAuthCorp/github-actions/helm/helm-chart-publish@main
+        with:
+          chart-path: charts/acp-cd
+          jf-token: ${{ secrets.ARTIFACTORY_PASSWORD }}
 
   kube-acp-stack:
     needs: acp
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Helm package charts/kube-acp-stack
-        run: helm package -u charts/kube-acp-stack
-
-      - uses: jfrog/setup-jfrog-cli@v1
-        env:
-          JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_SECRET_1 }}
-
-      - name: Publish
-        run: jfrog rt u *.tgz acp-helm-charts
+      - name: Publish Kube ACP Stack Chart
+        uses: SecureAuthCorp/github-actions/helm/helm-chart-publish@main
+        with:
+          chart-path: charts/kube-acp-stack
+          jf-token: ${{ secrets.ARTIFACTORY_PASSWORD }}
 
   openbanking:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Helm package charts/openbanking
-        run: helm package charts/openbanking
-
-      - uses: jfrog/setup-jfrog-cli@v1
-        env:
-          JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_SECRET_1 }}
-
-      - name: Publish
-        run: jfrog rt u *.tgz acp-helm-charts
+      - name: Publish OpenBanking Chart
+        uses: SecureAuthCorp/github-actions/helm/helm-chart-publish@main
+        with:
+          chart-path: charts/openbanking
+          jf-token: ${{ secrets.ARTIFACTORY_PASSWORD }}
 
   istio-authorizer:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Helm package charts/istio-authorizer
-        run: helm package charts/istio-authorizer
-
-      - uses: jfrog/setup-jfrog-cli@v1
-        env:
-          JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_SECRET_1 }}
-
-      - name: Publish
-        run: jfrog rt u *.tgz acp-helm-charts
+      - name: Publish Istio Authorizer Chart
+        uses: SecureAuthCorp/github-actions/helm/helm-chart-publish@main
+        with:
+          chart-path: charts/istio-authorizer
+          jf-token: ${{ secrets. ARTIFACTORY_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,8 +33,8 @@ jobs:
           jf-token: ${{ secrets.ARTIFACTORY_PASSWORD }}
 
   kube-acp-stack:
-    needs: acp
     runs-on: ubuntu-latest
+    needs: acp
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -67,4 +67,4 @@ jobs:
         uses: SecureAuthCorp/github-actions/helm/helm-chart-publish@main
         with:
           chart-path: charts/istio-authorizer
-          jf-token: ${{ secrets. ARTIFACTORY_PASSWORD }}
+          jf-token: ${{ secrets.ARTIFACTORY_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Build & Publish Helm Chart
 on:
   push:
     branches:
-      - master
+      - ocihelmchart
     paths:
       - "**/Chart.yaml"
 

--- a/charts/acp/Chart.yaml
+++ b/charts/acp/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: acp
 description: Cloudentity Authorization Control Plane
 type: application
-version: 2.27.1
+version: 2.27.2
 appVersion: "2.27.0"

--- a/charts/kube-acp-stack/Chart.yaml
+++ b/charts/kube-acp-stack/Chart.yaml
@@ -19,6 +19,6 @@ dependencies:
     repository: https://charts.timescale.com
     condition: timescaledb-single.enabled
   - name: acp
-    version: "2.27.1"
+    version: "2.27.2"
     repository: https://charts.cloudentity.io
     condition: acp.enabled

--- a/charts/openbanking/Chart.yaml
+++ b/charts/openbanking/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: openbanking
 description: Openbanking collects Cloudentity Openbanking apps to provide easy to operate end-to-end Kubernetes cluster
 type: application
-version: 0.1.9
+version: 0.2.0
 appVersion: "1.11.1"
 sources:
   - https://github.com/cloudentity/acp-helm-charts


### PR DESCRIPTION
## Summary
- Migrated all chart publish jobs to use the shared `SecureAuthCorp/github-actions/helm/helm-chart-publish@main` reusable action : https://github.com/SecureAuthCorp/github-actions/blob/main/helm/helm-chart-publish/action.yaml

it will deploy the chart to the new chart repository which is helm.secureauth.com

## JIRA
https://secureauth.atlassian.net/browse/DEVOPS-8110