### PR TITLE
chore(security): pin external GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/acp-cd-test.yaml
+++ b/.github/workflows/acp-cd-test.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Helm lint
         run: make helm-lint
       - name: Check kubernetes APIs

--- a/.github/workflows/acp-test.yaml
+++ b/.github/workflows/acp-test.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Helm lint
         run: make helm-lint
       - name: Kubeconform lint
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Prepare
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}

--- a/.github/workflows/istio-authorizer-test.yaml
+++ b/.github/workflows/istio-authorizer-test.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Helm lint
         run: make helm-lint
       - name: Kubeconform lint
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Prepare
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}

--- a/.github/workflows/kube-acp-stack-test.yaml
+++ b/.github/workflows/kube-acp-stack-test.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Helm lint
         run: make helm-lint
       - name: Kubeconform lint
@@ -33,6 +33,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Compare acp chart dependency version
         run: make check-acp-charts-version

--- a/.github/workflows/openbanking-test.yaml
+++ b/.github/workflows/openbanking-test.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Helm lint
         run: make helm-lint
       - name: Kubeconform lint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
       - name: Helm package charts/acp
         run: helm package charts/acp
 
-      - uses: jfrog/setup-jfrog-cli@v1
+      - uses: jfrog/setup-jfrog-cli@686845529f661c9afbbee4547baa1f6d2d7ce5e0 # v1.2.1
         env:
           JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_SECRET_1 }}
 
@@ -28,12 +28,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
       - name: Helm package charts/acp-cd
         run: helm package charts/acp-cd
 
-      - uses: jfrog/setup-jfrog-cli@v1
+      - uses: jfrog/setup-jfrog-cli@686845529f661c9afbbee4547baa1f6d2d7ce5e0 # v1.2.1
         env:
           JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_SECRET_1 }}
 
@@ -45,12 +45,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
       - name: Helm package charts/kube-acp-stack
         run: helm package -u charts/kube-acp-stack
 
-      - uses: jfrog/setup-jfrog-cli@v1
+      - uses: jfrog/setup-jfrog-cli@686845529f661c9afbbee4547baa1f6d2d7ce5e0 # v1.2.1
         env:
           JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_SECRET_1 }}
 
@@ -61,12 +61,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
       - name: Helm package charts/openbanking
         run: helm package charts/openbanking
 
-      - uses: jfrog/setup-jfrog-cli@v1
+      - uses: jfrog/setup-jfrog-cli@686845529f661c9afbbee4547baa1f6d2d7ce5e0 # v1.2.1
         env:
           JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_SECRET_1 }}
 
@@ -77,12 +77,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
       - name: Helm package charts/istio-authorizer
         run: helm package charts/istio-authorizer
 
-      - uses: jfrog/setup-jfrog-cli@v1
+      - uses: jfrog/setup-jfrog-cli@686845529f661c9afbbee4547baa1f6d2d7ce5e0 # v1.2.1
         env:
           JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_SECRET_1 }}
 

--- a/.github/workflows/release-branch.yaml
+++ b/.github/workflows/release-branch.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
       - name: Set ACP version
         run: sed -i.bak "s/ACP_VERSION ?=.*/ACP_VERSION ?= ${{ env.ACP_VERSION }}/" Makefile && rm -rf Makefile.bak

--- a/.github/workflows/update-helm-chart-default-values.yaml
+++ b/.github/workflows/update-helm-chart-default-values.yaml
@@ -22,11 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
         with:
           token: ${{ secrets.CLOUDENTITY_CI_TOKEN }}
       - name: Set key & value
-        uses: mikefarah/yq@v4.34.1
+        uses: mikefarah/yq@5ef537f3fd1a9437aa3ee44c32c6459a126efdc4 # v4.34.1
         with:
           cmd: yq '${{ inputs.key }} = "${{ inputs.value }}"' charts/${{ inputs.chart }}/values.yaml > charts/${{ inputs.chart }}/values-updated.yaml
       - name: Keep empty lines
@@ -34,7 +34,7 @@ jobs:
           diff -U0 -w -b --ignore-blank-lines charts/${{ inputs.chart }}/values.yaml charts/${{ inputs.chart }}/values-updated.yaml > charts/${{ inputs.chart }}/values.yaml.diff || true
           patch charts/${{ inputs.chart }}/values.yaml < charts/${{ inputs.chart }}/values.yaml.diff
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5.0.3
         with:
           token: ${{ secrets.GH_SERVICE_ACCOUNT_DEVOPS_2_PAT1 }}
           branch: "feature/update-${{ inputs.chart }}-${{ inputs.key }}"

--- a/.github/workflows/update-helm-chart-faas-images.yaml
+++ b/.github/workflows/update-helm-chart-faas-images.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set Environment Variables
         run: |
           echo "NODE_V5=${{ github.event.inputs.node_v5 }}" >> $GITHUB_ENV
@@ -57,7 +57,7 @@ jobs:
             fi
           done
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5.0.3
         with:
           token: ${{ secrets.GH_SERVICE_ACCOUNT_DEVOPS_2_PAT1 }}
           branch: "feature/update-faas-images"


### PR DESCRIPTION
## Jira task - N/A

## Release Notes Description (public)

N/A — internal CI/CD hardening only; no customer-facing change.

## Implementation details (internal)

Pin every external third-party action referenced by this repo's GitHub Actions workflows to a full-length commit SHA, with a trailing comment recording the human-readable version. A mutable tag (e.g. `v4`, `master`) can be silently re-pointed at malicious code by a compromised upstream maintainer (the `tj-actions/changed-files` incident class); a commit SHA is immutable, so CI always runs the exact code that was reviewed.

This extends the policy already applied in the `github-actions` repo (PR #90) to this repository. Same-org `SecureAuthCorp/github-actions/*` references are intentionally left on their floating refs, consistent with that PR's deliberate scope.

### Pinned references

- `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5`
- `actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5`
- `jfrog/setup-jfrog-cli@686845529f661c9afbbee4547baa1f6d2d7ce5e0`
- `mikefarah/yq@5ef537f3fd1a9437aa3ee44c32c6459a126efdc4`
- `peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5`

## Information for QA

- [ ] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?
