### PR TITLE
chore: add Renovate configuration

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,22 @@
+name: Renovate
+on:
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: Dry Run
+        default: "null"
+        required: false
+      logLevel:
+        description: Log Level
+        default: info
+        required: false
+  schedule:
+    - cron: "0 21 * * 0"
+
+jobs:
+  renovate:
+    uses: SecureAuthCorp/github-actions/.github/workflows/renovate.yaml@main
+    with:
+      dryRun: ${{ inputs.dryRun }}
+      logLevel: ${{ inputs.logLevel }}
+    secrets: inherit

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    ":disableRateLimiting"
+  ],
+  "timezone": "Etc/UTC",
+  "labels": ["dependencies", "renovate"],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "github actions (minor/patch)"
+    },
+    {
+      "matchManagers": ["helmv3"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "helm chart dependencies (minor/patch)"
+    },
+    {
+      "description": "acp chart/image version is driven by the release-branch workflow (make bump-acp-version), not Renovate.",
+      "matchPackageNames": ["acp"],
+      "enabled": false
+    }
+  ],
+  "customManagers": [
+    {
+      "description": "pluto release baked into the root Dockerfile. Tags are vX.Y.Z; the ARG stores X.Y.Z, so strip the leading v.",
+      "customType": "regex",
+      "fileMatch": ["^Dockerfile$"],
+      "matchStrings": ["ARG PLUTO_VERSION=(?<currentValue>.+)"],
+      "depNameTemplate": "FairwindsOps/pluto",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)$"
+    },
+    {
+      "description": "kubeconform release baked into the root Dockerfile. The ARG stores the vX.Y.Z tag verbatim.",
+      "customType": "regex",
+      "fileMatch": ["^Dockerfile$"],
+      "matchStrings": ["ARG KUBECONFORM_VERSION=(?<currentValue>.+)"],
+      "depNameTemplate": "yannh/kubeconform",
+      "datasourceTemplate": "github-releases"
+    }
+  ]
+}


### PR DESCRIPTION
## Jira task - N/A

## Release Notes Description (public)

N/A — internal tooling change, not customer-facing.

## Implementation details (internal)

Wires Renovate into the repo, mirroring the setup added to ciam-authorizers.

- `renovate.json`: extends `config:recommended`, `:dependencyDashboard`, `:semanticCommits`, `:disableRateLimiting`; UTC timezone; `dependencies`/`renovate` labels.
- GitHub Actions across all workflows are managed by the built-in manager; minor/patch grouped into one PR.
- `helmv3` manages the third-party chart dependencies in `kube-acp-stack` (cockroachdb, redis-cluster, timescaledb-single); minor/patch grouped.
- The `acp` chart dependency is disabled — its version is driven by the `release-branch` workflow (`make bump-acp-version`).
- Custom regex managers track `pluto` and `kubeconform` versions in the root `Dockerfile` (`alpine/helm` base is covered by the docker manager).
- `.github/workflows/renovate.yaml`: scheduled weekly (Sun 21:00 UTC) + `workflow_dispatch`, delegating to the shared `SecureAuthCorp/github-actions` reusable workflow.

## Information for QA

- [ ] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?

N/A — no chart/application changes. `renovate.json` validated locally with the official `renovate-config-validator`.

Developed with assistance of [Claude Code](https://claude.com/claude-code)
