### PR TITLE
fix: pass istio-authorizer namespace to debug step

### DIFF
--- a/.github/workflows/istio-authorizer-test.yaml
+++ b/.github/workflows/istio-authorizer-test.yaml
@@ -57,4 +57,4 @@ jobs:
         run: NAMESPACE=istio-authorizer make helm-test
       - name: Debug
         if: failure()
-        run: make debug
+        run: NAMESPACE=istio-authorizer make debug


### PR DESCRIPTION
## Jira task - N/A

## Release Notes Description (public)

N/A — CI-only change, no customer-facing impact.

## Implementation details (internal)

**Summary**: The `Debug` step in the `istio-authorizer chart test` workflow ran `make debug` without setting `NAMESPACE`, so it fell back to the Makefile default (`acp-system`). Since the istio-authorizer chart is installed in the `istio-authorizer` namespace, the failure diagnostics returned nothing useful (`No resources found in acp-system namespace.`), hiding the real cause (e.g. `ImagePullBackOff`).

**Changes**:
- `.github/workflows/istio-authorizer-test.yaml`: run `NAMESPACE=istio-authorizer make debug`, aligning the Debug step with the install/wait/helm-test steps in the same job.

**Testing**: Verified against [run #198 attempt 7](https://github.com/SecureAuthCorp/iam-saas-helm-charts/actions/runs/27943331073), where `kubectl describe pod ... --namespace acp-system` returned no resources while the failing pod was in `istio-authorizer`. YAML validated.

## Information for QA

- [ ] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?

Developed with assistance of [Claude Code](https://claude.com/claude-code)