### PR TITLE
fix: run Renovate self-hosted instead of via the private shared workflow

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -13,10 +13,21 @@ on:
   schedule:
     - cron: "0 21 * * 0"
 
+# This repo is public, so it cannot call the private SecureAuthCorp/github-actions
+# reusable Renovate workflow. Renovate runs self-hosted here instead, using the
+# DevOps service-account PAT so the dependency PRs trigger the chart test workflows.
 jobs:
   renovate:
-    uses: SecureAuthCorp/github-actions/.github/workflows/renovate.yaml@main
-    with:
-      dryRun: ${{ inputs.dryRun }}
-      logLevel: ${{ inputs.logLevel }}
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@eb932558ad942cccfd8211cf535f17ff183a9f74 # v46.1.9
+        with:
+          token: ${{ secrets.GH_SERVICE_ACCOUNT_DEVOPS_2_PAT1 }}
+        env:
+          RENOVATE_PLATFORM: github
+          RENOVATE_AUTODISCOVER: "false"
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_DRY_RUN: ${{ inputs.dryRun }}
+          RENOVATE_PRINT_CONFIG: "true"
+          LOG_LEVEL: ${{ inputs.logLevel }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -13,17 +13,18 @@ on:
   schedule:
     - cron: "0 21 * * 0"
 
-# This repo is public, so it cannot call the private SecureAuthCorp/github-actions
-# reusable Renovate workflow. Renovate runs self-hosted here instead, using the
-# DevOps service-account PAT so the dependency PRs trigger the chart test workflows.
+# Public repo: it can't call the private shared Renovate workflow, so run it self-hosted.
 jobs:
   renovate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@eb932558ad942cccfd8211cf535f17ff183a9f74 # v46.1.9
         with:
-          token: ${{ secrets.GH_SERVICE_ACCOUNT_DEVOPS_2_PAT1 }}
+          token: ${{ secrets.GITHUB_TOKEN }}
         env:
           RENOVATE_PLATFORM: github
           RENOVATE_AUTODISCOVER: "false"


### PR DESCRIPTION
## Jira task - N/A

## Release Notes Description (public)

N/A — internal tooling change, not customer-facing.

## Implementation details (internal)

Fixes the Renovate workflow merged in #340, which failed at startup (`startup_failure` — "workflow was not found"). Root cause: this repo is **public**, and GitHub does not allow a public repo to call a reusable workflow stored in the **private** `SecureAuthCorp/github-actions` repo. Every other (private) consumer of the shared workflow works; this is the only public one.

- Replaces the reusable-workflow call with a self-hosted `renovatebot/github-action` run scoped to this repo (`RENOVATE_REPOSITORIES`, autodiscover off).
- Authenticates with the default `GITHUB_TOKEN` (job granted `contents: write` + `pull-requests: write`) — no dependency on the private shared repo or org PAT secrets.
- `renovate.json` is unchanged.

Note: PRs opened by `GITHUB_TOKEN` do not trigger the repo's `on: pull_request` chart tests (GitHub's recursion safeguard), so Renovate PRs need CI re-run manually (or switch to a service-account PAT later if auto-CI is required).

## Information for QA

- [ ] Is QA testing required?
- [ ] Does PR contain unit tests?
- [ ] Should QA create E2E tests for the change?

N/A — workflow YAML validated with actionlint. Will confirm by manually dispatching the workflow (dryRun) once merged.

Developed with assistance of [Claude Code](https://claude.com/claude-code)
